### PR TITLE
System prompt messages should be separate from user messages in bedrock provider.

### DIFF
--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -279,6 +279,11 @@ impl BedrockProvider {
     // Helper method to transform Bedrock response to OpenAI format
     fn transform_bedrock_to_openai_format(&self, bedrock_response: Value) -> Result<Value, AppError> {
         debug!("Transforming Bedrock response to OpenAI format");
+
+        let metrics = bedrock_response
+            .get("metrics")
+            .cloned()
+            .unwrap_or_else(|| json!({}));        
         
         // Extract content from Bedrock response
         let content = bedrock_response
@@ -314,6 +319,7 @@ impl BedrockProvider {
         
         // Create OpenAI format response
         let openai_response = json!({
+            "metrics":metrics,
             "id": format!("chatcmpl-{}", uuid::Uuid::new_v4().to_string().replace("-", "").chars().take(10).collect::<String>()),
             "object": "chat.completion",
             "created": chrono::Utc::now().timestamp(),

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -1,3 +1,4 @@
+use std::env;
 use super::Provider;
 use super::utils::log_tracking_headers;
 use crate::error::AppError;
@@ -33,11 +34,13 @@ pub struct BedrockProvider {
     is_streaming: Arc<RwLock<bool>>,
     system_fingerprint: Arc<RwLock<String>>,
     first_chunk: Arc<RwLock<bool>>,
+    aws_key: Option<Arc<RwLock<String>>>,
+    aws_secret: Option<Arc<RwLock<String>>>,
 }
 
 impl BedrockProvider {
     pub fn new() -> Self {
-        let region = std::env::var("AWS_REGION").unwrap_or_else(|_| DEFAULT_REGION.to_string());
+        let region = env::var("AWS_REGION").unwrap_or_else(|_| DEFAULT_REGION.to_string());
         debug!("Initializing BedrockProvider with region: {}", region);
         
         // Create a random system fingerprint that will be reused across chunks
@@ -53,6 +56,12 @@ impl BedrockProvider {
             is_streaming: Arc::new(RwLock::new(false)),
             system_fingerprint: Arc::new(RwLock::new(fingerprint)),
             first_chunk: Arc::new(RwLock::new(true)),
+            aws_key: env::var("AWS_ACCESS_KEY_ID")
+                .ok()
+                .map(|key| Arc::new(RwLock::new(key))),
+            aws_secret: env::var("AWS_SECRET_ACCESS_KEY")
+                .ok()
+                .map(|key| Arc::new(RwLock::new(key))),
         }
     }
 

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -37,7 +37,7 @@ pub struct BedrockProvider {
 
 impl BedrockProvider {
     pub fn new() -> Self {
-        let region = DEFAULT_REGION.to_string();
+        let region = std::env::var("AWS_REGION").unwrap_or_else(|_| DEFAULT_REGION.to_string());
         debug!("Initializing BedrockProvider with region: {}", region);
         
         // Create a random system fingerprint that will be reused across chunks

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -457,11 +457,6 @@ impl Provider for BedrockProvider {
 
 
     fn get_signing_credentials(&self, headers: &HeaderMap) -> Option<(String, String, String)> {
-        
-        // let access_key = headers.get("x-aws-access-key-id")?.to_str().ok()?;
-        // let secret_key = headers.get("x-aws-secret-access-key")?.to_str().ok()?;
-        
-        
         let region = headers
             .get("x-aws-region")
             .and_then(|h| h.to_str().ok())
@@ -478,8 +473,6 @@ impl Provider for BedrockProvider {
             .and_then(|v| v.to_str().ok().map(|s| s.to_owned()))
             .or_else(|| self.aws_secret.as_ref().map(|arc| arc.read().clone()))?;
         
-        
-        //Some((access_key.to_string(), secret_key.to_string(), region))
         debug!( //
             "AWS credentials - Access Key: {} s: {}, Region: {}", 
             mask_key(access_key.as_str()), mask_key(secret_key.as_str()), region,


### PR DESCRIPTION
https://github.com/Noveum/ai-gateway/issues/23
The changes include collecting "system" role messages separately from "user" role messages. 
After that "user" and "assistant" role  messages go to "messages" field in body, the array of "system" role messages go into "system" field in request body.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using AWS credentials and region from environment variables.
  * Enhanced request handling to allow AWS credentials from request headers, with secure logging of masked credentials.

* **Improvements**
  * System messages are now separated into a distinct section in request payloads.
  * Responses now include a metrics field for additional insights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->