### PR TITLE
feat(edge): run the gateway as a Cloudflare Worker (WASM) — full provider + Nova Guard parity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ Apollo
 build/
 .wrangler/
 node_modules/
+.dev.vars

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ Cargo.lock
 # End of https://www.toptal.com/developers/gitignore/api/rust
 Apollo
 
+build/
+.wrangler/
+node_modules/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ exclude = [
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
+# Cloudflare Worker (worker-build/wasm-pack) build settings. wasm-opt is disabled
+# here because it requires a binaryen install on PATH; enable it in CI once
+# binaryen is available to shrink the bundle further.
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
 [profile.release]
 opt-level = 3
 lto = "fat"
@@ -34,41 +40,71 @@ panic = "abort"
 strip = true
 debug = false
 
+# One package, three deployment shapes:
+#   * native binary / Docker  → `cargo build` (default, x86_64/arm64)
+#   * Rust library            → `noveum-ai-gateway` as a dependency (rlib)
+#   * Cloudflare Worker (edge)→ `cargo build --target wasm32-unknown-unknown` (cdylib)
+# The Nova Guard engine + pricing + policy types in `[dependencies]` compile to
+# BOTH targets; runtime-specific deps are split by target below.
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+# The native server binary. `required-features = ["native"]` (on by default) keeps
+# it OUT of the wasm32 / Cloudflare Worker build, which is compiled with
+# `--no-default-features` (the Worker entry point is the cdylib lib, not a bin).
+[[bin]]
+name = "noveum-ai-gateway"
+path = "src/main.rs"
+required-features = ["native"]
+
+[features]
+default = ["native"]
+# Marker feature gating the native binary; native runtime deps are selected by
+# target (`cfg(not(target_arch = "wasm32"))`), not by this feature.
+native = []
+
+# --- Shared core: compiles on native AND wasm32 (Nova Guard, pricing, types) ---
 [dependencies]
+http = "1.0"
+bytes = { version = "1.5.0", features = ["serde"] }
+futures = "0.3"
+futures-util = { version = "0.3", features = ["io"] }
+once_cell = "1.18"
+thiserror = "2.0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = { version = "0.1", features = ["attributes"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.15.1", features = ["serde", "v4"] }
+regex = "1.12"                 # linear-time, ReDoS-safe matching (RegexSet, size limits)
+aho-corasick = "1.1"           # fast multi-pattern banned-substring matching
+jsonschema = { version = "0.46", default-features = false }  # JSON Schema validation (no http/file $ref resolvers — wasm-safe)
+arc-swap = "1.7"               # lock-free read-mostly policy cache
+
+# --- Native only: the Tokio/Axum server (Docker, binary, library server) ---
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 axum = { version = "0.7", features = ["http2", "tokio"] }
 tokio = { version = "1.0", features = ["full", "parking_lot", "rt-multi-thread"] }
 tokio-stream = "0.1"
 hyper = { version = "0.14", features = ["client", "runtime"] }
 tower-http = { version = "0.6.2", features = ["cors", "compression-full"] }
-tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 reqwest = { version = "0.12.9", features = ["stream", "json", "rustls-tls", "http2", "gzip", "brotli"], default-features = false }
-http = "1.0"
-bytes = { version = "1.5.0", features = ["serde"] }
 dotenv = "0.15"
-futures-util = { version = "0.3", features = ["io"] }
-futures = "0.3"
-once_cell = "1.18"
 async-trait = "0.1"
-thiserror = "2.0.3"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 num_cpus = "1.15"
 aws-sigv4 = "1.2.5"
 aws-credential-types = "1.2.1"
-chrono = { version = "0.4", features = ["serde"] }
 aws_event_stream_parser = "0.1.2"
 parking_lot = "0.12"
-uuid = { version = "1.15.1", features = ["serde", "v4"] }
 colored = "2.1.0"
-
-# --- Nova Guard policy-enforcement layer ---
-regex = "1.12"                 # linear-time, ReDoS-safe matching (RegexSet, size limits)
-aho-corasick = "1.1"           # fast multi-pattern banned-substring matching
-jsonschema = "0.46"            # JSON Schema validation for structured-output policies
-tiktoken-rs = "0.12"           # token counting for cost estimation / token-cap policies
-arc-swap = "1.7"               # lock-free read-mostly policy cache
+tiktoken-rs = "0.12"           # token counting (native); wasm uses a char heuristic
 async-stream = "0.3"           # SSE tee for post-call streaming policy evaluation
+
+# --- Cloudflare Worker only: WASM runtime + edge fetch ---
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+worker = { version = "0.8", features = ["http"] }
+uuid = { version = "1.15.1", features = ["js"] }   # v4 randomness on wasm
 
 [dev-dependencies]
 noveum-ai-gateway = { path = "." }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,8 @@ chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.15.1", features = ["serde", "v4"] }
 regex = "1.12"                 # linear-time, ReDoS-safe matching (RegexSet, size limits)
 aho-corasick = "1.1"           # fast multi-pattern banned-substring matching
+sha2 = "0.10"                  # pure-Rust SHA-256 for AWS SigV4 (edge Bedrock); wasm-safe
+hmac = "0.12"                  # pure-Rust HMAC-SHA256 for the SigV4 signing-key chain
 jsonschema = { version = "0.46", default-features = false }  # JSON Schema validation (no http/file $ref resolvers — wasm-safe)
 arc-swap = "1.7"               # lock-free read-mostly policy cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,12 @@ WORKDIR /usr/src/app
 # Copy only necessary files first
 COPY Cargo.toml Cargo.lock ./
 
-# Create a dummy main.rs to build dependencies
+# Create dummy sources to pre-build dependencies. The crate now exposes BOTH a
+# library target (the Cloudflare Worker / Rust-library shape — see [lib] in
+# Cargo.toml) and the binary, so cargo needs src/lib.rs to exist here too.
 RUN mkdir src && \
     echo "fn main() {}" > src/main.rs && \
+    echo "" > src/lib.rs && \
     cargo build --release --target x86_64-unknown-linux-gnu && \
     rm -rf src
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@
 - 📊 **Telemetry & Metrics**: Per-request token usage and cost tracking with a pluggable `MetricsExporter` trait; ships with a console exporter (set `DEBUG_METRICS=true`) for local debugging. See [docs/telemetry-plugins.md](docs/telemetry-plugins.md).
 - 🌐 **CORS Support**: Configurable cross-origin resource sharing
 - 🛠️ **SDK Compatibility**: Works with any OpenAI-compatible SDK
+- 🌍 **Deploy anywhere — one package, three shapes**: the same crate runs as a
+  native binary / **Docker** image, a **Rust library**, **or** a
+  **Cloudflare Worker** (WASM, true per‑PoP edge) sharing the same Nova Guard
+  engine. See [docs/CLOUDFLARE_WORKER.md](docs/CLOUDFLARE_WORKER.md).
 
 ## ⚡ Performance
 

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -1,0 +1,192 @@
+# Deploying the Noveum AI Gateway on Cloudflare (Distributed Edge)
+
+Research + migration plan for running the gateway as a globally‑distributed
+Cloudflare service. Current as of **June 2026**.
+
+## TL;DR
+
+Yes — there are **two viable paths**, with very different effort/payoff:
+
+| | **A. Cloudflare Containers** | **B. Cloudflare Workers (Rust → WASM)** |
+|---|---|---|
+| Code changes | **~none** (run the existing Docker image) | **substantial rewrite** of the runtime + I/O layers |
+| Distribution | Global (330+ cities), instance placed in optimal location | **True per‑PoP edge** in 330+ cities (V8 isolates) |
+| Cold start | Container spin‑up (100s of ms – seconds) | **~0** (isolate) |
+| Cost model | Workers Paid ($5/mo) + per‑10ms active CPU + memory/disk | Per‑request + per‑CPU‑ms (cheapest) |
+| Limits | ~container limits (memory/vCPU/disk) | 128 MB mem (hard), 5 min CPU (hard), 30s CPU default, WASM bundle‑size limit |
+| Best for | "Ship globally now, zero rewrite" | "Maximally distributed, lowest latency/cost, long‑term" |
+
+**Recommendation: a phased approach** — go live on **Containers** immediately
+(fast, no rewrite), then incrementally build a **Workers‑native** version for the
+hot path (the OpenAI‑compatible providers), which is where the true edge win is.
+
+> Why not "just compile it to a Worker"? Cloudflare Workers run on V8 isolates and
+> execute Rust as **WebAssembly (`wasm32-unknown-unknown`)**. That environment has
+> **no threaded async runtime (no Tokio), no native sockets, no `reqwest`/`hyper`,
+> and no native crypto (`ring`/`aws-lc`)**. Our current stack is built on exactly
+> those. So a Worker port is a real engineering project, not a recompile.
+
+---
+
+## How Cloudflare runs code (the constraint that drives everything)
+
+- **Workers = V8 isolates.** Rust is supported via [`workers-rs`](https://github.com/cloudflare/workers-rs)
+  (`worker` crate, currently 0.8.x) compiled to `wasm32-unknown-unknown` with
+  `wrangler`. Async/await works, but there is **no Tokio runtime / no threads /
+  no `mio` / no `tokio::net` / no `tokio::time` multi‑thread**. `tokio::sync`
+  primitives are fine. Outbound HTTP must use **`worker::Fetch`** (the platform
+  fetch API), not `reqwest`/`hyper`. Crypto must use the **Web Crypto API**
+  (`crypto.subtle`), not `ring`/`aws-lc-rs`.
+- **Containers = real Linux containers** at the edge (GA since Apr 2026). Run **any
+  x86‑64 Docker image unmodified**, fronted by a Worker, placed in the optimal
+  location. Requires Workers Paid; billed per 10 ms of active CPU.
+
+### Relevant platform limits (Workers)
+- Memory: **128 MB hard**. CPU: **30 s default, 5 min hard** (per invocation).
+- Subrequests: **10,000** default now (was 1,000); free plan = 50 external. A
+  gateway makes ~1 upstream call/request, so this is a non‑issue.
+- **WASM bundle size** matters — large embedded data (e.g. tiktoken BPE tables)
+  risks the bundle/startup limits.
+
+Sources: see bottom.
+
+---
+
+## Dependency reality check (this codebase → `wasm32-unknown-unknown`)
+
+| Dependency / subsystem | On Workers (WASM)? | Action for a Worker port |
+|---|---|---|
+| `tokio` (features = full, rt-multi-thread) | ❌ pulls in `mio`/native net; won't compile | Drop the runtime; use the `worker` executor + `tokio` with only `sync`/`macros` if needed |
+| `reqwest` + `hyper` (proxy client) | ❌ not on Workers | Rewrite outbound calls with **`worker::Fetch`** |
+| `axum` (server) + `tower-http` | ⚠️ axum *routing* works via the `http` feature; server/compression do not | Use the `worker` router (or `axum` with `worker` http shim); drop `tower-http` compression |
+| `aws-sigv4` + `aws-credential-types` (Bedrock signing) | ❌ needs native crypto | **Reimplement SigV4 with Web Crypto** (HMAC‑SHA256 via `crypto.subtle`) |
+| `tiktoken-rs` (token_length_cap) | ⚠️ large embedded BPE + `fancy-regex`; bundle/wasm risk | Replace with a lightweight heuristic or a WASM‑safe tokenizer; or keep precise counts only on Containers |
+| `jsonschema` (json_schema policy) | ⚠️ verify wasm32 build | Test; swap for a wasm‑friendly validator if needed |
+| `regex`, `aho-corasick` | ✅ pure Rust | Keep (Nova Guard regex/banned/secrets/PII) |
+| `arc-swap`, `parking_lot`, `bytes`, `serde`, `serde_json`, `thiserror`, `futures(-util)`, `async-stream` | ✅ | Keep |
+| `chrono` (timestamps) | ⚠️ `now()` needs the wasm/js path | Use `worker::Date` or `js-sys::Date` for time |
+| `uuid` v4 | ⚠️ needs `getrandom` `js` feature on wasm | Add `getrandom = { features = ["js"] }` for wasm, or use `worker`/Web Crypto randomness |
+| `tracing-subscriber`, `colored`, `num_cpus`, `dotenv` | ❌ server/CLI only | Drop on Workers; log via `console_log!`/`worker` |
+| `aws_event_stream_parser` (Bedrock streaming) | ⚠️ parsing is pure but tied to the Bedrock path | Port with the Bedrock rewrite (or keep Bedrock on Containers) |
+
+**What ports cleanly:** the whole **Nova Guard deterministic engine** (regex,
+banned substrings, secrets, PII, model allowlist — all `regex`/`aho-corasick`),
+the **pricing/cost table**, and the request/response transform logic are pure
+Rust and are the easy, high‑value part to run at the edge.
+
+**What is hard:** the **proxy core** (`reqwest`→`worker::Fetch`, including
+streaming SSE pass‑through), **Bedrock SigV4** (→ Web Crypto), **tiktoken**
+(token caps), and **time/RNG** wasm features.
+
+---
+
+## Recommended plan (phased)
+
+### Phase 0 — Decision + scaffolding
+- [ ] Confirm the target: Containers‑first (fast) vs Workers‑native (edge‑max) vs both.
+- [ ] Create a Cloudflare account on **Workers Paid** ($5/mo) — required for both
+      Containers and meaningful Workers usage.
+- [ ] Add `wrangler` + a `wrangler.toml` (or `.jsonc`) to the repo.
+
+### Phase 1 — Cloudflare Containers (fast global win, ~no code changes)
+- [ ] Reuse the existing `Dockerfile` (already builds a static `x86_64` binary on
+      `rust:1.96`). Ensure it binds `0.0.0.0:$PORT` (it does, via `HOST`/`PORT`).
+- [ ] Add a thin **Worker + Durable Object** front that routes incoming requests to
+      a `Container` binding (the standard Cloudflare Containers pattern).
+- [ ] Wire env/secrets (provider keys are passed per‑request via headers, so the
+      container itself needs little config beyond `NOVEUM_GUARD_*`).
+- [ ] Load‑test, confirm streaming pass‑through works through the Worker→Container hop.
+- [ ] **Outcome:** the full gateway (all 13 providers incl. Bedrock, full Nova
+      Guard) runs globally, unmodified. Trade‑off: container cold‑starts + higher
+      cost than isolates; not literally per‑PoP.
+
+### Phase 2 — Workers‑native core (the real edge play)
+Build a parallel `worker`‑based crate (workspace member or feature‑gated build)
+that handles the **OpenAI‑compatible providers** (OpenAI, Groq, Together,
+Fireworks, Mistral, Cohere, Gemini, DeepSeek, xAI, OpenRouter, Perplexity — i.e.
+everything except Bedrock):
+- [ ] Scaffold with `worker` 0.8.x + `wrangler`; target `wasm32-unknown-unknown`.
+- [ ] **Router:** port the `/v1/*` + `/health` routes to the `worker` router.
+- [ ] **Proxy:** reimplement `proxy_request_to_provider` using `worker::Fetch`
+      (`base_url + transform_path(path) + query`, header passthrough, **streaming
+      response pass‑through** via `worker::Response` streaming).
+- [ ] **Nova Guard:** compile the existing `policy` engine to wasm32 (regex/PII/
+      secrets/banned/model‑allowlist all port directly). Replace `tiktoken-rs`
+      (token caps) with a heuristic or wasm‑safe tokenizer; verify/replace
+      `jsonschema`.
+- [ ] **Metrics:** keep per‑request token/cost extraction (pure); ship telemetry
+      via a Worker‑friendly path (e.g. a subrequest, Workers Analytics Engine, or
+      Queues) instead of the Tokio‑spawned exporter.
+- [ ] **Time/RNG:** `worker::Date`/`getrandom js` for timestamps + ids.
+- [ ] Optimize WASM bundle size (`wasm-opt`, `default-features = false`, strip).
+- [ ] **Outcome:** the most common providers run as true per‑PoP edge Workers
+      (instant cold start, cheapest, lowest latency worldwide).
+
+### Phase 3 — Bedrock on Workers (optional, hardest)
+- [ ] Reimplement **AWS SigV4** signing with **Web Crypto** (`crypto.subtle`
+      HMAC‑SHA256 chain) and port the Bedrock Converse request/response + event‑
+      stream transforms to `worker::Fetch`.
+- [ ] Until then, **route `x-provider: bedrock` to the Container** (a Worker can
+      fall back to the Container binding for providers not yet ported) — a clean
+      hybrid.
+
+### Phase 4 — State & distribution niceties (optional)
+- [ ] Hosted **Nova Guard policies** at the edge via **Workers KV** (replace the
+      local file/inline bundle; cache‑on‑read, global propagation) — this also
+      revives the deferred "hosted policies" idea without a custom control plane.
+- [ ] **Durable Objects** for any cross‑request state we later want (e.g. real
+      `rate_limit`/`cost_cap` counters — the live‑state seam already exists in the
+      engine).
+- [ ] Per‑PoP caching, WAF, and Cloudflare rate‑limiting in front.
+
+---
+
+## Architecture (target hybrid)
+
+```
+            ┌──────────── Cloudflare global edge (330+ PoPs) ───────────┐
+client ───▶ │  Worker (WASM, workers-rs)                                │
+            │   • routes /v1/* + /health                                │
+            │   • Nova Guard (regex/PII/secrets/allowlist/json/token)   │
+            │   • OpenAI-compatible providers via worker::Fetch ────────┼──▶ OpenAI/Groq/…
+            │   • x-provider: bedrock ──▶ Container binding ────────────┼──▶ (Phase 1/3)
+            │   • policies from Workers KV; metrics via Analytics/Queue │
+            └───────────────────────────────────────────────────────────┘
+```
+
+## Concrete code-change checklist (Workers port)
+
+- `src/main.rs` → replace `#[tokio::main]` + `TcpListener` with a `#[event(fetch)]`
+  entry; drop the banner/`colored`/`num_cpus`.
+- `src/proxy/client.rs`, `src/proxy/mod.rs` → delete `reqwest`/`hyper`; implement
+  with `worker::Fetch` + `worker::Response` (incl. streaming).
+- `src/proxy/signing.rs` (`aws-sigv4`) → Web Crypto SigV4 (Phase 3) or container‑only.
+- `src/policy/rules/token_length_cap.rs` (`tiktoken-rs`) → heuristic/wasm tokenizer.
+- `src/telemetry/*` → replace Tokio‑spawned exporter with a Worker‑native sink.
+- `Cargo.toml` → wasm feature set: `default-features = false` everywhere; add
+  `worker`, `getrandom = { features=["js"] }`; gate native‑only deps behind a
+  `#[cfg(not(target_arch = "wasm32"))]` / Cargo feature so the **native binary
+  (Containers / `cargo install`) keeps working unchanged**.
+
+> Keep both targets in one crate via features (`native` vs `worker`) so the
+> published crate + Docker/Container build stay intact while the Worker build is
+> added.
+
+## Open questions / decisions for the team
+1. **Containers‑first, Workers‑first, or both?** (Recommendation: both, phased.)
+2. **Bedrock at the edge** worth the Web‑Crypto SigV4 rewrite, or keep on Containers?
+3. **Token caps** precision on Workers — heuristic acceptable, or required exact?
+4. **Telemetry sink** on Workers — Analytics Engine, Queues, or subrequest to Noveum?
+5. **Policy distribution** — move to Workers KV now (and retire the local‑file model at the edge)?
+
+## Sources
+- [workers-rs (GitHub)](https://github.com/cloudflare/workers-rs)
+- [Cloudflare Workers — Rust language support](https://developers.cloudflare.com/workers/languages/rust/)
+- [Supported crates · Workers Rust](https://developers.cloudflare.com/workers/languages/rust/crates/)
+- [`worker` crate docs](https://docs.rs/worker/latest/worker/)
+- [Workers platform limits](https://developers.cloudflare.com/workers/platform/limits/)
+- [Workers are no longer limited to 1000 subrequests (Feb 2026)](https://developers.cloudflare.com/changelog/post/2026-02-11-subrequests-limit/)
+- [Cloudflare Containers — product](https://www.cloudflare.com/products/containers/)
+- [Cloudflare Containers — pricing](https://developers.cloudflare.com/containers/pricing/)
+- [workers-rs issue #736 — wasm compile (mio/getrandom) pitfalls](https://github.com/cloudflare/workers-rs/issues/736)
+- [Making Rust Workers reliable (Cloudflare blog)](https://blog.cloudflare.com/making-rust-workers-reliable/)

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -68,9 +68,17 @@ native. The request/response transforms (`apply_input_transforms`,
 are one shared codebase used by both targets — verified live against OpenAI,
 Groq, Gemini, and Anthropic on `noveum-ai-gateway.<account>.workers.dev`.
 
-**Remaining:** **Bedrock** (the one provider still needing AWS SigV4 via Web
-Crypto, `crypto.subtle`); edge telemetry sink + Workers-KV policies; re-enable
-`wasm-opt`.
+**Phase 3 — DONE (verified live).** **Bedrock** now runs on the edge: OpenAI →
+Bedrock Converse request, **AWS SigV4** signing implemented in pure Rust
+(`sha2`+`hmac` in `src/sigv4.rs`; simpler + more reliable than async Web Crypto,
+and unit-tested in native CI against RFC 4231), Converse→OpenAI response
+conversion, and **temporary-credential support** (`x-aws-session-token`) that the
+native path lacks. Verified live against `amazon.nova-micro-v1:0` with temporary
+STS credentials, including Nova Guard input block + redaction.
+
+**All 13 providers now run on the edge. Remaining:** edge telemetry sink +
+Workers-KV policies; re-enable `wasm-opt`; (optional) add session-token support
+to the native Bedrock path for full parity.
 
 ## How Cloudflare runs code (the constraint that drives everything)
 

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -59,8 +59,18 @@ native server, from one codebase:
 
 See **[CLOUDFLARE_WORKER.md](CLOUDFLARE_WORKER.md)** for build/test/deploy steps.
 
-**Remaining:** output-phase + SSE streaming on the edge; Anthropic + Bedrock
-(Web-Crypto SigV4); edge telemetry sink + Workers-KV policies; `wasm-opt`.
+**Phase 2 — DONE (verified live on the global edge).** Anthropic (path/auth
+transform + Anthropic→OpenAI response conversion), Nova Guard input redaction,
+Nova Guard output-phase enforcement (block + redact, with an 8 MB inspection
+cap), and SSE streaming pass-through all work on the edge with full parity to
+native. The request/response transforms (`apply_input_transforms`,
+`flatten_output_text`, `rewrite_output_text`, `transform_anthropic_to_openai_format`)
+are one shared codebase used by both targets — verified live against OpenAI,
+Groq, Gemini, and Anthropic on `noveum-ai-gateway.<account>.workers.dev`.
+
+**Remaining:** **Bedrock** (the one provider still needing AWS SigV4 via Web
+Crypto, `crypto.subtle`); edge telemetry sink + Workers-KV policies; re-enable
+`wasm-opt`.
 
 ## How Cloudflare runs code (the constraint that drives everything)
 

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -3,22 +3,32 @@
 Research + migration plan for running the gateway as a globally‑distributed
 Cloudflare service. Current as of **June 2026**.
 
-## TL;DR
+## TL;DR — chosen direction
 
-Yes — there are **two viable paths**, with very different effort/payoff:
+**Primary: native Cloudflare Workers (Rust → WASM).** Containers add container
+cold‑start + higher cost and are not true per‑PoP, so they are **not** the fast
+path; we target the native Worker (V8 isolates, ~0 cold start, every PoP). We
+**keep the existing native binary + Docker image fully working** for self‑hosting
+(no Cloudflare Containers dependency), sharing **one Nova Guard engine** across
+both builds so they never diverge.
 
-| | **A. Cloudflare Containers** | **B. Cloudflare Workers (Rust → WASM)** |
+| | **Native Worker (WASM)** — primary edge | **Native binary / Docker** — self‑host (kept) |
 |---|---|---|
-| Code changes | **~none** (run the existing Docker image) | **substantial rewrite** of the runtime + I/O layers |
-| Distribution | Global (330+ cities), instance placed in optimal location | **True per‑PoP edge** in 330+ cities (V8 isolates) |
-| Cold start | Container spin‑up (100s of ms – seconds) | **~0** (isolate) |
-| Cost model | Workers Paid ($5/mo) + per‑10ms active CPU + memory/disk | Per‑request + per‑CPU‑ms (cheapest) |
-| Limits | ~container limits (memory/vCPU/disk) | 128 MB mem (hard), 5 min CPU (hard), 30s CPU default, WASM bundle‑size limit |
-| Best for | "Ship globally now, zero rewrite" | "Maximally distributed, lowest latency/cost, long‑term" |
+| Runtime | V8 isolate, `wasm32-unknown-unknown` via `workers-rs` | Tokio + Axum + reqwest (today's binary) |
+| Distribution | **True per‑PoP edge**, 330+ cities, ~0 cold start | Wherever the operator runs it |
+| Outbound HTTP | `worker::Fetch` | `reqwest` |
+| Crypto (Bedrock SigV4) | **Web Crypto** (`crypto.subtle` HMAC‑SHA256) | `aws-sigv4` |
+| Token caps | heuristic / wasm‑safe tokenizer | `tiktoken-rs` |
+| Built from | new `worker/` crate | existing `noveum-ai-gateway` crate (published, unchanged) |
 
-**Recommendation: a phased approach** — go live on **Containers** immediately
-(fast, no rewrite), then incrementally build a **Workers‑native** version for the
-hot path (the OpenAI‑compatible providers), which is where the true edge win is.
+**Shared core:** the Nova Guard engine (regex/PII/secrets/banned/model‑allowlist/
+json‑schema), pricing/cost, and provider base‑URL/path mapping live in one place
+and compile to **both** native and wasm32, so the edge Worker and the self‑hosted
+binary enforce identically.
+
+> Cloudflare **Containers** remain a documented fallback (run the same Docker
+> image) for anyone who wants the full native feature set without the WASM build —
+> but they are not the primary deployment.
 
 > Why not "just compile it to a Worker"? Cloudflare Workers run on V8 isolates and
 > execute Rust as **WebAssembly (`wasm32-unknown-unknown`)**. That environment has
@@ -27,6 +37,30 @@ hot path (the OpenAI‑compatible providers), which is where the true edge win i
 > those. So a Worker port is a real engineering project, not a recompile.
 
 ---
+
+## Implementation status
+
+**Phase 1 — DONE (single package, three targets).** The `noveum-ai-gateway` crate
+now compiles to `wasm32-unknown-unknown` as a Cloudflare Worker *and* to the
+native server, from one codebase:
+- Cargo deps split by target (`cfg(not(target_arch = "wasm32"))` = native server;
+  `cfg(target_arch = "wasm32")` = `worker`); the native binary is gated by a
+  `native` feature so the wasm build (`--no-default-features`) excludes it.
+- Native-only modules (`proxy`, `handlers`, `config`, `providers`, `telemetry`,
+  `error`, axum router) are `cfg`-gated; the **Nova Guard engine + pricing +
+  `routing`** are shared and compile to both.
+- `src/worker_rt.rs` is the `#[event(fetch)]` entry: `/health`, Nova Guard input
+  enforcement via the shared engine, and proxy of the OpenAI-compatible providers
+  via `worker::Fetch`.
+- **Verified locally in `workerd` (`wrangler dev`):** real OpenAI + Groq proxy and
+  the SSN block behave identically to the native server. Native: 166 unit + 10
+  integration tests green; clippy clean on **both** targets; `worker-build`
+  produces a deployable bundle.
+
+See **[CLOUDFLARE_WORKER.md](CLOUDFLARE_WORKER.md)** for build/test/deploy steps.
+
+**Remaining:** output-phase + SSE streaming on the edge; Anthropic + Bedrock
+(Web-Crypto SigV4); edge telemetry sink + Workers-KV policies; `wasm-opt`.
 
 ## How Cloudflare runs code (the constraint that drives everything)
 

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -19,7 +19,7 @@ both builds so they never diverge.
 | Outbound HTTP | `worker::Fetch` | `reqwest` |
 | Crypto (Bedrock SigV4) | **Web Crypto** (`crypto.subtle` HMAC‑SHA256) | `aws-sigv4` |
 | Token caps | heuristic / wasm‑safe tokenizer | `tiktoken-rs` |
-| Built from | new `worker/` crate | existing `noveum-ai-gateway` crate (published, unchanged) |
+| Built from | the **same** `noveum-ai-gateway` crate (`--target wasm32 --no-default-features`) | the **same** crate (`cargo build`, default `native` feature) |
 
 **Shared core:** the Nova Guard engine (regex/PII/secrets/banned/model‑allowlist/
 json‑schema), pricing/cost, and provider base‑URL/path mapping live in one place
@@ -145,10 +145,11 @@ streaming SSE pass‑through), **Bedrock SigV4** (→ Web Crypto), **tiktoken**
       cost than isolates; not literally per‑PoP.
 
 ### Phase 2 — Workers‑native core (the real edge play)
-Build a parallel `worker`‑based crate (workspace member or feature‑gated build)
-that handles the **OpenAI‑compatible providers** (OpenAI, Groq, Together,
-Fireworks, Mistral, Cohere, Gemini, DeepSeek, xAI, OpenRouter, Perplexity — i.e.
-everything except Bedrock):
+**Implemented in the single `noveum-ai-gateway` crate via target gating** (NOT a
+separate/workspace crate): the wasm32 build (`src/worker_rt.rs`, compiled with
+`--no-default-features`) handles **all OpenAI‑compatible providers + Anthropic**
+(OpenAI, Groq, Together, Fireworks, Mistral, Cohere, Gemini, DeepSeek, xAI,
+OpenRouter, Perplexity, Anthropic — everything except Bedrock):
 - [ ] Scaffold with `worker` 0.8.x + `wrangler`; target `wasm32-unknown-unknown`.
 - [ ] **Router:** port the `/v1/*` + `/health` routes to the `worker` router.
 - [ ] **Proxy:** reimplement `proxy_request_to_provider` using `worker::Fetch`

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -82,16 +82,31 @@ After deploy, the gateway answers at `https://noveum-ai-gateway.<account>.worker
 
 ## What runs on the edge today vs. next
 
-**Working now (Phase 1):** `/health`; Nova Guard input enforcement (regex, PII,
-secrets, banned substrings, model allowlist, JSON-schema, token caps — the full
-shared engine); proxy + response pass-through for the OpenAI-compatible providers
-(`openai, groq, together, fireworks, mistral, cohere, google/gemini, deepseek,
-xai/grok, openrouter, perplexity`).
+**Working now — verified live on the global edge:**
+- `/health`.
+- **All OpenAI-compatible providers**: `openai, groq, together, fireworks,
+  mistral, cohere, google/gemini, deepseek, xai/grok, openrouter, perplexity`
+  (proxy + response pass-through).
+- **Anthropic**: path → `/v1/messages`, `Authorization: Bearer` → `x-api-key` +
+  `anthropic-version`, and the response converted back to OpenAI Chat Completions
+  shape — same as the native server.
+- **SSE streaming**: passed through unbuffered (input redaction still applies;
+  output-phase enforcement is skipped on streams — the documented v1 limitation,
+  identical to native).
+- **Nova Guard — input phase**: block + redact/mask (regex, PII, secrets, banned
+  substrings, model allowlist, JSON-schema, token caps — the full shared engine).
+  Input redactions are applied to the body *before* the upstream call.
+- **Nova Guard — output phase**: block + redact on non-streaming responses
+  (buffered up to an 8 MB inspection cap; larger responses pass through
+  uninspected, matching native).
 
-**Next phases (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
-- Output-phase enforcement + explicit SSE **streaming** pass-through.
-- **Anthropic** (path + `x-api-key` transform) and **Bedrock** (**AWS SigV4 via
-  Web Crypto**).
-- Telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
+The same Nova Guard policy schema, decisions, and redactions run here as on the
+native server (the engine + request/response shaping are one shared codebase).
+Note the redact replacement key is **`redactWith`** (see `wrangler.toml`).
+
+**Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
+- **Bedrock** — the one remaining provider; needs **AWS SigV4 via Web Crypto**
+  (`crypto.subtle`) since native crypto crates don't run on wasm.
+- Edge telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
 - Re-enable `wasm-opt` to shrink the bundle (currently ~3.3 MB unoptimized;
-  gzips well under the 10 MB paid-plan limit).
+  gzips to ~1 MB, well under the 10 MB paid-plan limit).

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -1,0 +1,97 @@
+# Running the Gateway as a Cloudflare Worker (edge)
+
+The **same `noveum-ai-gateway` crate** builds three ways. `wasm32` builds the
+Cloudflare Worker; native builds the server (Docker / binary / library). They
+share the Nova Guard engine + provider routing, so behavior is identical.
+
+| Shape | Build | Entry |
+|---|---|---|
+| Native binary / Docker | `cargo build --release` | `src/main.rs` (Axum + Tokio) |
+| Rust library | `noveum-ai-gateway` dep (rlib) | `lib.rs` |
+| **Cloudflare Worker** | `worker-build --release` (`cargo … --target wasm32 --no-default-features`) | `src/worker_rt.rs` (`#[event(fetch)]`) |
+
+## Prerequisites (one-time)
+
+```bash
+rustup target add wasm32-unknown-unknown
+cargo install worker-build           # Rust→WASM bundler for Workers
+npm i -g wrangler                    # or use `npx wrangler`
+# (optional, for smaller bundles) install binaryen so `wasm-opt` is on PATH,
+# then set `wasm-opt = true` in [package.metadata.wasm-pack.profile.release].
+```
+
+## Build the Worker bundle
+
+```bash
+worker-build --release
+# → build/worker/index.wasm  (the compiled gateway)
+#   build/worker/shim.mjs     (the JS entry wrangler serves)
+```
+
+## Test locally (no Cloudflare account needed)
+
+`wrangler dev` runs the Worker in `workerd` (the real runtime) on localhost:
+
+```bash
+npx wrangler dev --port 8787
+```
+
+Then exercise it exactly like the native gateway:
+
+```bash
+# Health
+curl localhost:8787/health
+# → {"status":"healthy","version":"1.1.0","runtime":"cloudflare-worker"}
+
+# Proxy an OpenAI-compatible provider (x-provider + Bearer key, OpenAI body)
+curl localhost:8787/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "x-provider: openai" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"hi"}]}'
+
+# Nova Guard block (the default wrangler.toml sets a block-SSN policy)
+curl -i localhost:8787/v1/chat/completions \
+  -H "Authorization: Bearer $OPENAI_API_KEY" -H "x-provider: openai" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ssn 123-45-6789"}]}'
+# → HTTP 200 with header `x-noveum-guard-blocked: true`
+```
+
+Verified locally: `/health`, OpenAI + Groq proxy (real upstreams), and the SSN
+block all behave identically to the native server.
+
+## Deploy to the global edge
+
+```bash
+npx wrangler login                       # authenticate to your Cloudflare account
+# Provider keys are passed PER REQUEST (Authorization header), so the Worker
+# itself needs no provider secrets. Set Nova Guard policy inline or via KV:
+#   - inline: edit NOVEUM_GUARD_POLICIES in wrangler.toml ([vars])
+#   - or a secret:  npx wrangler secret put NOVEUM_GUARD_POLICIES
+npx wrangler deploy                      # publishes to 330+ PoPs
+```
+
+After deploy, the gateway answers at `https://noveum-ai-gateway.<account>.workers.dev`
+(or a custom route/domain) from the nearest PoP to each caller.
+
+### Configuration (Worker `[vars]` / secrets)
+- `NOVEUM_GUARD_ENABLED` — `true`/`false` (default `true`).
+- `NOVEUM_GUARD_POLICIES` — inline `nova-guard.json` (same schema as the native
+  `NOVEUM_GUARD_POLICIES`/file). For production, prefer a **Workers KV** binding
+  so policies propagate globally without a redeploy.
+
+## What runs on the edge today vs. next
+
+**Working now (Phase 1):** `/health`; Nova Guard input enforcement (regex, PII,
+secrets, banned substrings, model allowlist, JSON-schema, token caps — the full
+shared engine); proxy + response pass-through for the OpenAI-compatible providers
+(`openai, groq, together, fireworks, mistral, cohere, google/gemini, deepseek,
+xai/grok, openrouter, perplexity`).
+
+**Next phases (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
+- Output-phase enforcement + explicit SSE **streaming** pass-through.
+- **Anthropic** (path + `x-api-key` transform) and **Bedrock** (**AWS SigV4 via
+  Web Crypto**).
+- Telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
+- Re-enable `wasm-opt` to shrink the bundle (currently ~3.3 MB unoptimized;
+  gzips well under the 10 MB paid-plan limit).

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -102,6 +102,13 @@ and are not inspected; only `application/json` bodies run through Nova Guard.
 - **SSE streaming**: passed through unbuffered (input redaction still applies;
   output-phase enforcement is skipped on streams — the documented v1 limitation,
   identical to native).
+- **Header + query pass-through**: client request headers (e.g. `OpenAI-Beta`,
+  `OpenAI-Organization`, `anthropic-beta`) and the query string are forwarded;
+  upstream response headers (`x-request-id`, rate-limit, …) are preserved. The
+  transparent path forwards the request body byte-for-byte (only redacted bodies
+  are re-serialized).
+- **CORS**: permissive (`*`) on all responses + `OPTIONS` preflight, matching the
+  native `CorsLayer`.
 - **Nova Guard — input phase**: block + redact/mask (regex, PII, secrets, banned
   substrings, model allowlist, JSON-schema, token caps — the full shared engine).
   Input redactions are applied to the body *before* the upstream call.

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -99,6 +99,21 @@ and are not inspected; only `application/json` bodies run through Nova Guard.
 - **Anthropic**: path → `/v1/messages`, `Authorization: Bearer` → `x-api-key` +
   `anthropic-version`, and the response converted back to OpenAI Chat Completions
   shape — same as the native server.
+- **Bedrock**: OpenAI → Bedrock **Converse** request, **AWS SigV4**-signed in pure
+  Rust (`sha2`+`hmac`; see `src/sigv4.rs`) with credentials from `x-aws-*` headers,
+  and the Converse response converted back to OpenAI shape. Unlike native, the
+  edge also accepts **temporary credentials** via `x-aws-session-token`. Pass
+  `x-aws-access-key-id`, `x-aws-secret-access-key`, `x-aws-region` (+ optional
+  `x-aws-session-token`) instead of `Authorization`:
+
+  ```bash
+  curl $GW/v1/chat/completions -H "x-provider: bedrock" \
+    -H "x-aws-access-key-id: $AWS_ACCESS_KEY_ID" \
+    -H "x-aws-secret-access-key: $AWS_SECRET_ACCESS_KEY" \
+    -H "x-aws-session-token: $AWS_SESSION_TOKEN" \
+    -H "x-aws-region: us-east-1" -H "Content-Type: application/json" \
+    -d '{"model":"amazon.nova-micro-v1:0","messages":[{"role":"user","content":"hi"}],"max_tokens":50}'
+  ```
 - **SSE streaming**: passed through unbuffered (input redaction still applies;
   output-phase enforcement is skipped on streams — the documented v1 limitation,
   identical to native).
@@ -120,9 +135,10 @@ The same Nova Guard policy schema, decisions, and redactions run here as on the
 native server (the engine + request/response shaping are one shared codebase).
 Note the redact replacement key is **`redactWith`** (see `wrangler.toml`).
 
-**Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
-- **Bedrock** — the one remaining provider; needs **AWS SigV4 via Web Crypto**
-  (`crypto.subtle`) since native crypto crates don't run on wasm.
+**All 13 providers now run on the edge** (OpenAI-compatible set + Anthropic +
+Bedrock). **Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
 - Edge telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
 - Re-enable `wasm-opt` to shrink the bundle (currently ~3.3 MB unoptimized;
   gzips to ~1 MB, well under the 10 MB paid-plan limit).
+- Optionally add `x-aws-session-token` support to the **native** Bedrock path too
+  (the edge already supports temporary credentials).

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -75,10 +75,19 @@ After deploy, the gateway answers at `https://noveum-ai-gateway.<account>.worker
 (or a custom route/domain) from the nearest PoP to each caller.
 
 ### Configuration (Worker `[vars]` / secrets)
-- `NOVEUM_GUARD_ENABLED` — `true`/`false` (default `true`).
+- The checked-in default is a **transparent proxy** — no policies, so nothing is
+  mutated or blocked until you opt in.
 - `NOVEUM_GUARD_POLICIES` — inline `nova-guard.json` (same schema as the native
-  `NOVEUM_GUARD_POLICIES`/file). For production, prefer a **Workers KV** binding
-  so policies propagate globally without a redeploy.
+  `NOVEUM_GUARD_POLICIES`/file). Setting it activates Nova Guard. For production,
+  prefer a **Workers KV** binding so policies propagate globally without a redeploy.
+- `NOVEUM_GUARD_ENABLED` — `true`/`false` (default `true`; with no policies it's
+  still a no-op).
+- `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` — `synthetic_success` (default: HTTP 200 with
+  a refusal-style completion) or `provider_error` (HTTP 403 + error envelope).
+  Identical to the native server.
+
+Non-JSON `/v1/*` request bodies (multipart, binary) are forwarded byte-for-byte
+and are not inspected; only `application/json` bodies run through Nova Guard.
 
 ## What runs on the edge today vs. next
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 // shape.
 pub mod policy;
 pub mod routing;
+pub mod sigv4;
 
 // Native runtime (Tokio + Axum server): the binary, Docker image, and library
 // server. Not compiled for the wasm32 (Cloudflare Worker) target.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,22 +19,43 @@
 #![allow(clippy::borrowed_box)]
 #![allow(clippy::redundant_closure)]
 
-pub mod config;
-pub mod error;
-pub mod handlers;
+// Shared core: compiles to BOTH the native server and the wasm32 Cloudflare
+// Worker, so guardrails + request routing behave identically on every deployment
+// shape.
 pub mod policy;
+pub mod routing;
+
+// Native runtime (Tokio + Axum server): the binary, Docker image, and library
+// server. Not compiled for the wasm32 (Cloudflare Worker) target.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod config;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod error;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod handlers;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod providers;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod proxy;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod telemetry;
 
+// Cloudflare Worker runtime (WASM): the `#[event(fetch)]` entry point + edge
+// proxy. Only compiled for wasm32.
+#[cfg(target_arch = "wasm32")]
+pub mod worker_rt;
+
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
 use axum::{
     middleware::from_fn_with_state,
     routing::{any, get},
     Router,
 };
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::{
     config::AppConfig,
     policy::PolicyEngine,
@@ -45,6 +66,7 @@ use crate::{
 ///
 /// `AppState` is intentionally cheap to clone (everything behind an `Arc`) so it
 /// can be attached to multiple Tower layers and handlers.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<AppConfig>,
@@ -54,6 +76,7 @@ pub struct AppState {
     pub policy: Arc<PolicyEngine>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl AppState {
     pub fn new(
         config: Arc<AppConfig>,
@@ -80,6 +103,7 @@ impl AppState {
 /// The policy middleware is always wired but becomes a transparent pass-through
 /// when the engine has no active policies, so enabling/disabling guardrails is a
 /// runtime concern, not a routing concern.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn build_router(state: AppState) -> Router {
     let cors = tower_http::cors::CorsLayer::new()
         .allow_origin(tower_http::cors::Any)

--- a/src/policy/engine.rs
+++ b/src/policy/engine.rs
@@ -11,6 +11,7 @@
 
 use std::borrow::Cow;
 use std::sync::Arc;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use arc_swap::ArcSwap;
@@ -167,6 +168,10 @@ impl PolicyEngine {
     ///
     /// Any load/parse error degrades to an empty (pass-through) engine with a
     /// warning; the gateway never fails to boot because of policy config.
+    ///
+    /// Native only (reads env + filesystem). The Cloudflare Worker builds the
+    /// engine from an in-memory bundle via [`PolicyEngine::from_bundle`].
+    #[cfg(not(target_arch = "wasm32"))]
     pub async fn from_env() -> Self {
         // Treat a broad set of falsey values as "disabled" (case-insensitive,
         // trimmed) so a kill-switch like `NOVEUM_GUARD_ENABLED=Off` actually
@@ -385,9 +390,15 @@ impl PolicyEngine {
                 input_tokens,
                 live_state,
             };
+            // `std::time::Instant` is unsupported on wasm32 (Cloudflare Worker)
+            // and panics; per-policy latency is telemetry only, so skip it there.
+            #[cfg(not(target_arch = "wasm32"))]
             let start = Instant::now();
             let outcome = cp.rule.evaluate(&ctx);
+            #[cfg(not(target_arch = "wasm32"))]
             let latency_ms = start.elapsed().as_secs_f64() * 1000.0;
+            #[cfg(target_arch = "wasm32")]
+            let latency_ms = 0.0_f64;
             let decision = Self::decision_from_outcome(&cp.meta, outcome, latency_ms);
 
             // Apply transform if enforced.

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -144,124 +144,11 @@ fn header_str<B>(req: &Request<B>, name: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-// Input flattening is shared with the Cloudflare Worker so the input scan is
-// identical on both deployment shapes.
-pub use crate::routing::flatten_input_text;
-
-/// Apply input transforms to every text segment in the body in place, including
-/// array-form (multimodal) content parts and array-form `system` blocks so that
-/// PII/secret redaction is never silently skipped for structured content.
-///
-/// Returns true if anything was mutated. Uses the engine's transform-only path
-/// (the aggregate block decision was already made over the flattened text), so
-/// blocking is not re-litigated per segment and cost/rate/token policies do not
-/// re-run here.
-fn apply_input_transforms(engine: &PolicyEngine, model: &str, json: &mut Value) -> bool {
-    let mut changed = false;
-    let transform = |s: &str| engine.apply_text_transforms(Phase::Input, model, s);
-
-    // Mutate one JSON string field in place if a transform changed it.
-    fn rewrite_string(
-        v: &mut Value,
-        transform: &dyn Fn(&str) -> Option<String>,
-        changed: &mut bool,
-    ) {
-        if let Value::String(s) = v {
-            if let Some(t) = transform(s) {
-                if &t != s {
-                    *v = Value::String(t);
-                    *changed = true;
-                }
-            }
-        }
-    }
-
-    // Mutate either a string field or every `.text` in an array-of-parts.
-    fn rewrite_content(
-        v: &mut Value,
-        transform: &dyn Fn(&str) -> Option<String>,
-        changed: &mut bool,
-    ) {
-        match v {
-            Value::String(_) => rewrite_string(v, transform, changed),
-            Value::Array(parts) => {
-                for part in parts.iter_mut() {
-                    if let Some(text) = part.get_mut("text") {
-                        rewrite_string(text, transform, changed);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    if let Some(prompt) = json.get_mut("prompt") {
-        rewrite_string(prompt, &transform, &mut changed);
-    }
-    if let Some(system) = json.get_mut("system") {
-        // Anthropic `system` may be a string or an array of text blocks.
-        rewrite_content(system, &transform, &mut changed);
-    }
-    if let Some(messages) = json.get_mut("messages").and_then(|m| m.as_array_mut()) {
-        for msg in messages.iter_mut() {
-            if let Some(content) = msg.get_mut("content") {
-                rewrite_content(content, &transform, &mut changed);
-            }
-        }
-    }
-
-    changed
-}
-
-/// Extract the assistant text from a provider response body.
-pub fn flatten_output_text(provider: &str, json: &Value) -> String {
-    match provider {
-        "anthropic" => json
-            .get("content")
-            .and_then(|c| c.as_array())
-            .map(|parts| {
-                parts
-                    .iter()
-                    .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            })
-            .unwrap_or_default(),
-        "google" | "gemini" => json
-            .get("candidates")
-            .and_then(|c| c.as_array())
-            .map(|cands| {
-                cands
-                    .iter()
-                    .filter_map(|c| c.get("content").and_then(|ct| ct.get("parts")))
-                    .filter_map(|p| p.as_array())
-                    .flat_map(|parts| {
-                        parts
-                            .iter()
-                            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            })
-            .unwrap_or_default(),
-        // OpenAI / compatible
-        _ => json
-            .get("choices")
-            .and_then(|c| c.as_array())
-            .map(|choices| {
-                choices
-                    .iter()
-                    .filter_map(|c| {
-                        c.get("message")
-                            .and_then(|m| m.get("content"))
-                            .and_then(|c| c.as_str())
-                    })
-                    .collect::<Vec<_>>()
-                    .join("\n")
-            })
-            .unwrap_or_default(),
-    }
-}
+// Request/response shaping is shared with the Cloudflare Worker so input/output
+// scanning + transforms are byte-identical on both deployment shapes.
+pub use crate::routing::{
+    apply_input_transforms, flatten_input_text, flatten_output_text, rewrite_output_text,
+};
 
 async fn enforce_output(
     engine: &PolicyEngine,
@@ -354,36 +241,6 @@ async fn enforce_output(
     }
 
     Response::from_parts(parts, Body::from(bytes))
-}
-
-/// Rewrite the first assistant text field with the transformed text. Best-effort
-/// for the common OpenAI/Anthropic shapes.
-fn rewrite_output_text(provider: &str, json: &mut Value, new_text: &str) -> bool {
-    match provider {
-        "anthropic" => {
-            if let Some(parts) = json.get_mut("content").and_then(|c| c.as_array_mut()) {
-                if let Some(first_text) = parts
-                    .iter_mut()
-                    .find(|p| p.get("text").map(|t| t.is_string()).unwrap_or(false))
-                {
-                    first_text["text"] = Value::String(new_text.to_string());
-                    return true;
-                }
-            }
-            false
-        }
-        _ => {
-            if let Some(choices) = json.get_mut("choices").and_then(|c| c.as_array_mut()) {
-                if let Some(first) = choices.first_mut() {
-                    if let Some(msg) = first.get_mut("message") {
-                        msg["content"] = Value::String(new_text.to_string());
-                        return true;
-                    }
-                }
-            }
-            false
-        }
-    }
 }
 
 fn log_decisions(

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -209,10 +209,13 @@ async fn enforce_output(
     // chat-completion shape BEFORE this middleware runs. Pick the flatten/transform
     // shape from the ACTUAL body, not the `x-provider` name, so output enforcement
     // never silently misses `choices[].message.content`.
+    // `x-provider` is case-insensitive; normalize so e.g. "Gemini" still matches
+    // the `candidates` shape instead of silently failing open.
+    let provider_key = provider.to_ascii_lowercase();
     let output_provider = if body_json.get("choices").is_some() {
         "openai"
     } else {
-        provider
+        provider_key.as_str()
     };
 
     let output_text = flatten_output_text(output_provider, &body_json);

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -205,7 +205,17 @@ async fn enforce_output(
         return Response::from_parts(parts, Body::from(bytes));
     };
 
-    let output_text = flatten_output_text(provider, &body_json);
+    // Native providers (notably Anthropic) convert the upstream body to OpenAI
+    // chat-completion shape BEFORE this middleware runs. Pick the flatten/transform
+    // shape from the ACTUAL body, not the `x-provider` name, so output enforcement
+    // never silently misses `choices[].message.content`.
+    let output_provider = if body_json.get("choices").is_some() {
+        "openai"
+    } else {
+        provider
+    };
+
+    let output_text = flatten_output_text(output_provider, &body_json);
     if output_text.is_empty() {
         return Response::from_parts(parts, Body::from(bytes));
     }
@@ -233,7 +243,7 @@ async fn enforce_output(
     // can't leak. Re-runs the transform per segment via the shared helper.
     if result.transformed_text.is_some() {
         let mut out_json = body_json;
-        if apply_output_transforms(engine, model, provider, &mut out_json) {
+        if apply_output_transforms(engine, model, output_provider, &mut out_json) {
             if let Ok(v) = serde_json::to_vec(&out_json) {
                 let mut parts = parts;
                 parts.headers.remove(header::CONTENT_LENGTH);

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -144,45 +144,9 @@ fn header_str<B>(req: &Request<B>, name: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
-/// Flatten the user-supplied input text from a chat/completions-style body.
-///
-/// Handles OpenAI/Anthropic `messages[].content` (string or array-of-parts),
-/// Anthropic top-level `system`, and a plain `prompt` string.
-pub fn flatten_input_text(json: &Value) -> String {
-    let mut out = String::new();
-
-    if let Some(system) = json.get("system").and_then(|s| s.as_str()) {
-        out.push_str(system);
-        out.push('\n');
-    }
-
-    if let Some(prompt) = json.get("prompt").and_then(|p| p.as_str()) {
-        out.push_str(prompt);
-        out.push('\n');
-    }
-
-    if let Some(messages) = json.get("messages").and_then(|m| m.as_array()) {
-        for msg in messages {
-            match msg.get("content") {
-                Some(Value::String(s)) => {
-                    out.push_str(s);
-                    out.push('\n');
-                }
-                Some(Value::Array(parts)) => {
-                    for part in parts {
-                        if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
-                            out.push_str(t);
-                            out.push('\n');
-                        }
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
-
-    out
-}
+// Input flattening is shared with the Cloudflare Worker so the input scan is
+// identical on both deployment shapes.
+pub use crate::routing::flatten_input_text;
 
 /// Apply input transforms to every text segment in the body in place, including
 /// array-form (multimodal) content parts and array-form `system` blocks so that

--- a/src/policy/middleware.rs
+++ b/src/policy/middleware.rs
@@ -147,7 +147,7 @@ fn header_str<B>(req: &Request<B>, name: &str) -> Option<String> {
 // Request/response shaping is shared with the Cloudflare Worker so input/output
 // scanning + transforms are byte-identical on both deployment shapes.
 pub use crate::routing::{
-    apply_input_transforms, flatten_input_text, flatten_output_text, rewrite_output_text,
+    apply_input_transforms, apply_output_transforms, flatten_input_text, flatten_output_text,
 };
 
 async fn enforce_output(
@@ -228,10 +228,12 @@ async fn enforce_output(
         return block_response(provider, model, block, engine.block_mode());
     }
 
-    // Output transform: rewrite the assistant text in place for the common shapes.
-    if let Some(transformed) = &result.transformed_text {
+    // Output transform: redact EVERY assistant text segment in place (all
+    // choices / content blocks), not just the first, so multi-choice responses
+    // can't leak. Re-runs the transform per segment via the shared helper.
+    if result.transformed_text.is_some() {
         let mut out_json = body_json;
-        if rewrite_output_text(provider, &mut out_json, transformed) {
+        if apply_output_transforms(engine, model, provider, &mut out_json) {
             if let Ok(v) = serde_json::to_vec(&out_json) {
                 let mut parts = parts;
                 parts.headers.remove(header::CONTENT_LENGTH);
@@ -322,19 +324,23 @@ mod tests {
     }
 
     #[test]
-    fn rewrite_openai_output_text() {
+    fn apply_output_transforms_redacts_all_openai_choices() {
+        // Output-phase email redaction over a multi-choice response: every choice
+        // must be rewritten (regression guard — the old helper did only the first).
+        let bundle = crate::policy::config::PolicyBundle::from_json_str(
+            r#"{"policies":[{"name":"red","type":"pii_detection","mode":"enforce","config":{"phase":"output","entities":["EMAIL_ADDRESS"],"action":"redact"}}]}"#,
+        )
+        .unwrap();
+        let e = PolicyEngine::from_bundle(&bundle, crate::policy::engine::EngineOptions::default());
         let mut j = serde_json::json!({
-            "choices": [{"message": {"role": "assistant", "content": "secret stuff"}}]
+            "choices": [
+                {"message": {"role": "assistant", "content": "ping a@b.com"}},
+                {"message": {"role": "assistant", "content": "or c@d.io"}}
+            ]
         });
-        assert!(rewrite_output_text("openai", &mut j, "[REDACTED]"));
-        assert_eq!(j["choices"][0]["message"]["content"], "[REDACTED]");
-    }
-
-    #[test]
-    fn rewrite_anthropic_output_text() {
-        let mut j = serde_json::json!({"content": [{"type": "text", "text": "secret"}]});
-        assert!(rewrite_output_text("anthropic", &mut j, "[X]"));
-        assert_eq!(j["content"][0]["text"], "[X]");
+        assert!(apply_output_transforms(&e, "gpt-4o", "openai", &mut j));
+        assert_eq!(j["choices"][0]["message"]["content"], "ping [REDACTED]");
+        assert_eq!(j["choices"][1]["message"]["content"], "or [REDACTED]");
     }
 
     fn redact_email_engine() -> PolicyEngine {

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -22,11 +22,19 @@
 pub mod config;
 pub mod decision;
 pub mod engine;
-pub mod middleware;
 pub mod pricing;
 pub mod rules;
-pub mod source;
 pub mod synthetic;
+
+// Local bundle loading reads the filesystem (`tokio::fs`) — native only. The
+// Worker builds the engine from an in-memory bundle (env var / KV) instead.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod source;
+
+// The Tower/Axum guard middleware is native-only; the Cloudflare Worker wires the
+// engine into `worker_rt` instead.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod middleware;
 
 pub use config::{Policy, PolicyBundle, PolicyType};
 pub use decision::{Phase, PolicyAction, PolicyDecision, PolicyMode, Severity};

--- a/src/policy/rules/token_length_cap.rs
+++ b/src/policy/rules/token_length_cap.rs
@@ -142,8 +142,14 @@ mod tests {
 
     #[test]
     fn estimate_tokens_is_reasonable() {
-        let n = estimate_tokens("Hello, world! This is a test sentence.");
+        let text = "Hello, world! This is a test sentence.";
+        let n = estimate_tokens(text);
+        // Native: exact BPE count (well under 30 for this short sentence).
+        #[cfg(not(target_arch = "wasm32"))]
         assert!(n > 0 && n < 30, "got {n}");
+        // wasm32: a safe UPPER bound == UTF-8 byte length (never undercounts).
+        #[cfg(target_arch = "wasm32")]
+        assert_eq!(n, text.len() as u32, "wasm estimate must equal byte length");
     }
 
     #[test]

--- a/src/policy/rules/token_length_cap.rs
+++ b/src/policy/rules/token_length_cap.rs
@@ -46,20 +46,26 @@ impl TokenLengthCapRule {
 /// Estimate token count for arbitrary text.
 ///
 /// Native builds use the exact `o200k_base` BPE encoding (cached singleton).
-/// The wasm32 / Cloudflare Worker build uses a `chars / 4` heuristic instead —
 /// `tiktoken-rs` bundles a multi-megabyte vocab and pulls `fancy-regex`, which
-/// would bloat the Worker bundle and risk the size/startup limits. The heuristic
-/// is conservative for a guardrail (it can only under-count pathological inputs).
+/// would bloat the Worker bundle, so the wasm32 build cannot use it.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn estimate_tokens(text: &str) -> u32 {
     let bpe = tiktoken_rs::o200k_base_singleton();
     bpe.encode_with_special_tokens(text).len() as u32
 }
 
-/// wasm32 token estimate: `ceil(chars / 4)` (≈ average English token length).
+/// wasm32 / Cloudflare Worker token estimate: a SAFE UPPER BOUND.
+///
+/// `TokenLengthCapRule` fires only when the estimate *exceeds* `max_tokens`, so
+/// the wasm estimator must never UNDER-count — otherwise an over-limit prompt
+/// (CJK, emoji, minified code) slips past the cap. For byte-level BPE (o200k),
+/// the token count is always ≤ the UTF-8 byte length (the base alphabet is
+/// single bytes; merges only ever reduce the count), so `text.len()` is a sound
+/// upper bound. It over-counts versus the exact native count, so the edge errs
+/// toward blocking — the correct failure mode for a guardrail.
 #[cfg(target_arch = "wasm32")]
 pub fn estimate_tokens(text: &str) -> u32 {
-    (text.chars().count() as f32 / 4.0).ceil() as u32
+    text.len().min(u32::MAX as usize) as u32
 }
 
 impl PolicyRule for TokenLengthCapRule {

--- a/src/policy/rules/token_length_cap.rs
+++ b/src/policy/rules/token_length_cap.rs
@@ -43,12 +43,23 @@ impl TokenLengthCapRule {
     }
 }
 
-/// Estimate token count for arbitrary text using the o200k_base encoding
-/// (cached singleton). Falls back to a chars/4 heuristic only if the encoder
-/// cannot be constructed (should not happen with the bundled vocab).
+/// Estimate token count for arbitrary text.
+///
+/// Native builds use the exact `o200k_base` BPE encoding (cached singleton).
+/// The wasm32 / Cloudflare Worker build uses a `chars / 4` heuristic instead —
+/// `tiktoken-rs` bundles a multi-megabyte vocab and pulls `fancy-regex`, which
+/// would bloat the Worker bundle and risk the size/startup limits. The heuristic
+/// is conservative for a guardrail (it can only under-count pathological inputs).
+#[cfg(not(target_arch = "wasm32"))]
 pub fn estimate_tokens(text: &str) -> u32 {
     let bpe = tiktoken_rs::o200k_base_singleton();
     bpe.encode_with_special_tokens(text).len() as u32
+}
+
+/// wasm32 token estimate: `ceil(chars / 4)` (≈ average English token length).
+#[cfg(target_arch = "wasm32")]
+pub fn estimate_tokens(text: &str) -> u32 {
+    (text.chars().count() as f32 / 4.0).ceil() as u32
 }
 
 impl PolicyRule for TokenLengthCapRule {

--- a/src/policy/synthetic.rs
+++ b/src/policy/synthetic.rs
@@ -14,15 +14,21 @@
 //! An `x_noveum_guard` extension object is attached so tooling can identify
 //! guard-synthesised responses; provider SDKs ignore unknown fields.
 
+// `BlockResponseMode` (the mode enum) is shared. The provider-shaped block
+// response builder is axum-based and native-only; the Cloudflare Worker builds
+// the equivalent JSON in `worker_rt` and wraps it in `worker::Response`.
+#[cfg(not(target_arch = "wasm32"))]
+use super::decision::PolicyDecision;
+#[cfg(not(target_arch = "wasm32"))]
 use axum::{
     body::Body,
     http::{header, StatusCode},
     response::Response,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use serde_json::{json, Value};
+#[cfg(not(target_arch = "wasm32"))]
 use uuid::Uuid;
-
-use super::decision::PolicyDecision;
 
 /// How a block should be surfaced to the caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,6 +48,7 @@ impl BlockResponseMode {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn guard_extension(decision: &PolicyDecision) -> Value {
     json!({
         "blocked": true,
@@ -57,6 +64,7 @@ fn guard_extension(decision: &PolicyDecision) -> Value {
 /// `provider` is the `x-provider` value (e.g. `"openai"`, `"anthropic"`,
 /// `"google"`); unknown providers fall back to the OpenAI shape, which most
 /// OpenAI-compatible SDKs accept.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn block_response(
     provider: &str,
     model: &str,
@@ -97,6 +105,7 @@ pub fn block_response(
         .expect("synthetic response with sanitized header is always valid")
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn reason_text(decision: &PolicyDecision) -> String {
     format!(
         "Request blocked by Nova Guard policy '{}': {}",
@@ -104,6 +113,7 @@ fn reason_text(decision: &PolicyDecision) -> String {
     )
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn error_body(provider: &str, decision: &PolicyDecision) -> Value {
     let message = reason_text(decision);
     match provider {
@@ -124,6 +134,7 @@ fn error_body(provider: &str, decision: &PolicyDecision) -> Value {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn success_body(provider: &str, model: &str, decision: &PolicyDecision) -> Value {
     let content = reason_text(decision);
     let id_suffix = Uuid::new_v4().to_string();

--- a/src/policy/synthetic.rs
+++ b/src/policy/synthetic.rs
@@ -14,21 +14,20 @@
 //! An `x_noveum_guard` extension object is attached so tooling can identify
 //! guard-synthesised responses; provider SDKs ignore unknown fields.
 
-// `BlockResponseMode` (the mode enum) is shared. The provider-shaped block
-// response builder is axum-based and native-only; the Cloudflare Worker builds
-// the equivalent JSON in `worker_rt` and wraps it in `worker::Response`.
-#[cfg(not(target_arch = "wasm32"))]
+// `BlockResponseMode` + the provider-shaped block *body* builders + status are
+// SHARED, so the native server and the Cloudflare Worker emit byte-identical
+// block responses. Only the axum `Response` wrapper is native-only; the Worker
+// wraps the same body/status in a `worker::Response`.
 use super::decision::PolicyDecision;
+use serde_json::{json, Value};
+use uuid::Uuid;
+
 #[cfg(not(target_arch = "wasm32"))]
 use axum::{
     body::Body,
     http::{header, StatusCode},
     response::Response,
 };
-#[cfg(not(target_arch = "wasm32"))]
-use serde_json::{json, Value};
-#[cfg(not(target_arch = "wasm32"))]
-use uuid::Uuid;
 
 /// How a block should be surfaced to the caller.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,7 +47,44 @@ impl BlockResponseMode {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+/// Sanitize a policy id to a safe ASCII header token (so building a response
+/// header can never fail). Shared by native + Worker.
+pub fn policy_header_token(policy_id: &str) -> String {
+    policy_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_graphic() && c != '\u{7f}' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .take(128)
+        .collect()
+}
+
+/// HTTP status for a block in the given mode (shared by native + Worker).
+pub fn block_status(mode: BlockResponseMode) -> u16 {
+    match mode {
+        BlockResponseMode::ProviderError => 403,
+        BlockResponseMode::SyntheticSuccess => 200,
+    }
+}
+
+/// Build the provider-shaped block response *body* for the given mode. Shared by
+/// native (`block_response`) and the Cloudflare Worker (`worker_rt`).
+pub fn block_body(
+    provider: &str,
+    model: &str,
+    decision: &PolicyDecision,
+    mode: BlockResponseMode,
+) -> Value {
+    match mode {
+        BlockResponseMode::ProviderError => error_body(provider, decision),
+        BlockResponseMode::SyntheticSuccess => success_body(provider, model, decision),
+    }
+}
+
 fn guard_extension(decision: &PolicyDecision) -> Value {
     json!({
         "blocked": true,
@@ -71,30 +107,10 @@ pub fn block_response(
     decision: &PolicyDecision,
     mode: BlockResponseMode,
 ) -> Response {
-    let body = match mode {
-        BlockResponseMode::ProviderError => error_body(provider, decision),
-        BlockResponseMode::SyntheticSuccess => success_body(provider, model, decision),
-    };
-    let status = match mode {
-        BlockResponseMode::ProviderError => StatusCode::FORBIDDEN,
-        BlockResponseMode::SyntheticSuccess => StatusCode::OK,
-    };
-
-    // Policy ids come from user/control-plane config and may contain characters
-    // that are invalid in an HTTP header value; sanitize to a safe ASCII token so
-    // building the response can never panic.
-    let policy_header: String = decision
-        .policy_id
-        .chars()
-        .map(|c| {
-            if c.is_ascii_graphic() && c != '\u{7f}' {
-                c
-            } else {
-                '_'
-            }
-        })
-        .take(128)
-        .collect();
+    let body = block_body(provider, model, decision, mode);
+    let status =
+        StatusCode::from_u16(block_status(mode)).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+    let policy_header = policy_header_token(&decision.policy_id);
 
     Response::builder()
         .status(status)
@@ -105,7 +121,6 @@ pub fn block_response(
         .expect("synthetic response with sanitized header is always valid")
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn reason_text(decision: &PolicyDecision) -> String {
     format!(
         "Request blocked by Nova Guard policy '{}': {}",
@@ -113,7 +128,6 @@ fn reason_text(decision: &PolicyDecision) -> String {
     )
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn error_body(provider: &str, decision: &PolicyDecision) -> Value {
     let message = reason_text(decision);
     match provider {
@@ -134,7 +148,6 @@ fn error_body(provider: &str, decision: &PolicyDecision) -> Value {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn success_body(provider: &str, model: &str, decision: &PolicyDecision) -> Value {
     let content = reason_text(decision);
     let id_suffix = Uuid::new_v4().to_string();

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -208,6 +208,18 @@ impl Provider for AnthropicProvider {
             // Extract the ID from the JSON response for later use
             let json_id = json.get("id").and_then(|v| v.as_str()).map(String::from);
 
+            // Only convert SUCCESSFUL Messages responses to OpenAI shape. For
+            // 4xx/5xx, preserve the upstream Anthropic error envelope + status
+            // (matches the edge Worker) instead of emitting an empty
+            // "chat.completion" payload.
+            if !parts.status.is_success() {
+                debug!(
+                    "Anthropic returned {}; passing the error body through unchanged",
+                    parts.status
+                );
+                return Ok(Response::from_parts(parts, Body::from(bytes)));
+            }
+
             // Transform Anthropic API response to OpenAI format (shared with the
             // edge Worker; timestamp passed in since chrono is wasm-unavailable).
             let transformed_response =

--- a/src/providers/anthropic.rs
+++ b/src/providers/anthropic.rs
@@ -10,6 +10,7 @@
 use super::utils::log_tracking_headers;
 use super::Provider;
 use crate::error::AppError;
+use crate::routing::transform_anthropic_to_openai_format;
 use crate::telemetry::provider_metrics::{MetricsExtractor, ProviderMetrics};
 use async_trait::async_trait;
 use axum::http::HeaderMap;
@@ -18,7 +19,7 @@ use axum::{
     http::{HeaderValue, Response},
 };
 use chrono;
-use serde_json::{json, Value};
+use serde_json::Value;
 use std::cell::RefCell;
 use tracing::{debug, error};
 
@@ -207,8 +208,10 @@ impl Provider for AnthropicProvider {
             // Extract the ID from the JSON response for later use
             let json_id = json.get("id").and_then(|v| v.as_str()).map(String::from);
 
-            // Transform Anthropic API response to OpenAI format
-            let transformed_response = transform_anthropic_to_openai_format(json);
+            // Transform Anthropic API response to OpenAI format (shared with the
+            // edge Worker; timestamp passed in since chrono is wasm-unavailable).
+            let transformed_response =
+                transform_anthropic_to_openai_format(json, chrono::Utc::now().timestamp());
             debug!("Transformed Anthropic response to OpenAI format");
 
             // Ensure x-request-id header is set in the response
@@ -418,115 +421,10 @@ impl MetricsExtractor for AnthropicMetricsExtractor {
 }
 
 // Convert Anthropic API response format to OpenAI format
-fn transform_anthropic_to_openai_format(anthropic_response: Value) -> Value {
-    // Extract content from Anthropic's array-based content structure
-    let content =
-        if let Some(content_array) = anthropic_response.get("content").and_then(|c| c.as_array()) {
-            // Extract text content from content array (typically contains objects with "type" and "text")
-            let mut text = String::new();
-            for item in content_array {
-                if let Some(item_text) = item.get("text").and_then(|t| t.as_str()) {
-                    text.push_str(item_text);
-                }
-            }
-            text
-        } else {
-            // Fallback if content structure is different
-            anthropic_response
-                .get("content")
-                .and_then(|c| c.as_str())
-                .unwrap_or("")
-                .to_string()
-        };
-
-    // Map Anthropic usage fields to OpenAI format
-    let usage = {
-        let mut usage_map = json!({
-            "prompt_tokens": 0,
-            "completion_tokens": 0,
-            "total_tokens": 0
-        });
-
-        if let Some(anthropic_usage) = anthropic_response.get("usage") {
-            // Map input_tokens to prompt_tokens
-            if let Some(input_tokens) = anthropic_usage.get("input_tokens").and_then(|t| t.as_u64())
-            {
-                usage_map["prompt_tokens"] = json!(input_tokens);
-            }
-
-            // Map output_tokens to completion_tokens
-            if let Some(output_tokens) = anthropic_usage
-                .get("output_tokens")
-                .and_then(|t| t.as_u64())
-            {
-                usage_map["completion_tokens"] = json!(output_tokens);
-            }
-
-            // Calculate total tokens
-            let prompt_tokens = usage_map["prompt_tokens"].as_u64().unwrap_or(0);
-            let completion_tokens = usage_map["completion_tokens"].as_u64().unwrap_or(0);
-            usage_map["total_tokens"] = json!(prompt_tokens + completion_tokens);
-        }
-
-        usage_map
-    };
-
-    // Map stop_reason to finish_reason (Anthropic uses "end_turn", "max_tokens", etc.)
-    let finish_reason = match anthropic_response
-        .get("stop_reason")
-        .and_then(|r| r.as_str())
-    {
-        Some("end_turn") => "stop",
-        Some("max_tokens") => "length",
-        Some("stop_sequence") => "stop",
-        Some(reason) => reason,
-        None => "stop", // Default
-    };
-
-    // Create OpenAI-compatible format
-    let mut transformed = json!({
-        "id": anthropic_response.get("id").unwrap_or(&Value::Null),
-        "object": "chat.completion",
-        "created": chrono::Utc::now().timestamp(),
-        "model": anthropic_response.get("model").unwrap_or(&Value::Null),
-        "type": anthropic_response.get("type").unwrap_or(&json!("message")),
-        "role": anthropic_response.get("role").unwrap_or(&json!("assistant")),
-        "choices": [{
-            "index": 0,
-            "message": {
-                "role": anthropic_response.get("role").unwrap_or(&json!("assistant")),
-                "content": content
-            },
-            "finish_reason": finish_reason
-        }],
-        "usage": usage,
-        "system_fingerprint": format!("anthropic-{}", anthropic_response.get("model").and_then(|m| m.as_str()).unwrap_or("claude"))
-    });
-
-    // Handle the seed value - convert to string if present to avoid integer overflow in downstream stores
-    if let Some(seed) = anthropic_response.get("seed") {
-        if let Some(choices) = transformed
-            .get_mut("choices")
-            .and_then(|c| c.as_array_mut())
-        {
-            for choice in choices {
-                if seed.is_number() {
-                    // Convert the numeric seed to a string to avoid integer range issues in downstream stores
-                    choice["seed"] = json!(seed.to_string());
-                } else {
-                    // If it's already a string or other type, just preserve it
-                    choice["seed"] = seed.clone();
-                }
-            }
-        }
-    }
-
-    transformed
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     fn hdr(auth: Option<&str>) -> HeaderMap {
         let mut h = HeaderMap::new();
@@ -600,8 +498,9 @@ mod tests {
             "stop_reason": "end_turn",
             "usage": {"input_tokens": 5, "output_tokens": 2}
         });
-        let out = transform_anthropic_to_openai_format(anthropic);
+        let out = transform_anthropic_to_openai_format(anthropic, 1_700_000_000);
         assert_eq!(out["object"], "chat.completion");
+        assert_eq!(out["created"], 1_700_000_000);
         assert_eq!(out["choices"][0]["message"]["content"], "Hello world");
         assert_eq!(out["choices"][0]["finish_reason"], "stop");
         assert_eq!(out["usage"]["prompt_tokens"], 5);

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,0 +1,189 @@
+//! Shared request-routing helpers used by BOTH the native server and the
+//! Cloudflare Worker, so provider resolution and input flattening behave
+//! identically on every deployment shape.
+
+use serde_json::Value;
+
+/// Where an OpenAI-compatible request should be forwarded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ProviderRoute {
+    /// Upstream base URL (no trailing slash).
+    pub base_url: &'static str,
+    /// Strip the leading `/v1` from the request path before appending it to
+    /// `base_url` (for bases that already carry a version segment).
+    pub strip_v1: bool,
+}
+
+/// Resolve the OpenAI-compatible upstream for an `x-provider` value.
+///
+/// Returns `None` for providers that need request/auth transforms beyond simple
+/// pass-through (currently `anthropic` and `bedrock`), which the edge handles in
+/// later phases. Mirrors the native `providers::create_provider` base URLs.
+pub fn resolve_provider(name: &str) -> Option<ProviderRoute> {
+    let (base_url, strip_v1) = match name.to_lowercase().as_str() {
+        "openai" => ("https://api.openai.com", false),
+        "groq" => ("https://api.groq.com/openai", false),
+        "together" => ("https://api.together.xyz", false),
+        "fireworks" => ("https://api.fireworks.ai/inference/v1", true),
+        "mistral" => ("https://api.mistral.ai", false),
+        "deepseek" => ("https://api.deepseek.com", false),
+        "xai" | "grok" => ("https://api.x.ai", false),
+        "openrouter" => ("https://openrouter.ai/api", false),
+        "perplexity" => ("https://api.perplexity.ai", true),
+        "google" | "gemini" => (
+            "https://generativelanguage.googleapis.com/v1beta/openai",
+            true,
+        ),
+        "cohere" => ("https://api.cohere.ai/compatibility/v1", true),
+        _ => return None,
+    };
+    Some(ProviderRoute { base_url, strip_v1 })
+}
+
+/// Build the upstream URL for a proxied request.
+pub fn upstream_url(route: &ProviderRoute, request_path: &str) -> String {
+    let path = if route.strip_v1 {
+        request_path.strip_prefix("/v1").unwrap_or(request_path)
+    } else {
+        request_path
+    };
+    format!("{}{}", route.base_url, path)
+}
+
+/// Flatten the user-supplied input text from a chat/completions-style body.
+///
+/// Handles OpenAI/Anthropic `messages[].content` (string or array-of-parts),
+/// Anthropic top-level `system` (string or array-of-parts), and a plain
+/// `prompt` string. This is the text Nova Guard scans on the input phase.
+pub fn flatten_input_text(json: &Value) -> String {
+    let mut out = String::new();
+
+    match json.get("system") {
+        Some(Value::String(s)) => {
+            out.push_str(s);
+            out.push('\n');
+        }
+        Some(Value::Array(parts)) => {
+            for part in parts {
+                if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                    out.push_str(t);
+                    out.push('\n');
+                }
+            }
+        }
+        _ => {}
+    }
+
+    if let Some(prompt) = json.get("prompt").and_then(|p| p.as_str()) {
+        out.push_str(prompt);
+        out.push('\n');
+    }
+
+    if let Some(messages) = json.get("messages").and_then(|m| m.as_array()) {
+        for msg in messages {
+            match msg.get("content") {
+                Some(Value::String(s)) => {
+                    out.push_str(s);
+                    out.push('\n');
+                }
+                Some(Value::Array(parts)) => {
+                    for part in parts {
+                        if let Some(t) = part.get("text").and_then(|t| t.as_str()) {
+                            out.push_str(t);
+                            out.push('\n');
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn resolves_openai_compatible_providers() {
+        assert_eq!(
+            resolve_provider("openai").unwrap(),
+            ProviderRoute {
+                base_url: "https://api.openai.com",
+                strip_v1: false
+            }
+        );
+        // case-insensitive
+        assert_eq!(
+            resolve_provider("GROQ").unwrap().base_url,
+            "https://api.groq.com/openai"
+        );
+        assert_eq!(
+            resolve_provider("grok").unwrap().base_url,
+            "https://api.x.ai"
+        );
+        assert!(resolve_provider("gemini").unwrap().strip_v1);
+        assert!(resolve_provider("perplexity").unwrap().strip_v1);
+        // not pure pass-through (yet) on the edge
+        assert!(resolve_provider("anthropic").is_none());
+        assert!(resolve_provider("bedrock").is_none());
+        assert!(resolve_provider("nope").is_none());
+    }
+
+    #[test]
+    fn builds_upstream_url_with_and_without_v1_strip() {
+        let openai = resolve_provider("openai").unwrap();
+        assert_eq!(
+            upstream_url(&openai, "/v1/chat/completions"),
+            "https://api.openai.com/v1/chat/completions"
+        );
+        let gemini = resolve_provider("gemini").unwrap();
+        assert_eq!(
+            upstream_url(&gemini, "/v1/chat/completions"),
+            "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+        );
+        let fireworks = resolve_provider("fireworks").unwrap();
+        assert_eq!(
+            upstream_url(&fireworks, "/v1/chat/completions"),
+            "https://api.fireworks.ai/inference/v1/chat/completions"
+        );
+    }
+
+    #[test]
+    fn flattens_string_content_system_and_prompt() {
+        let j = json!({
+            "model": "gpt-4o",
+            "system": "be terse",
+            "messages": [{"role": "user", "content": "hello world"}]
+        });
+        let t = flatten_input_text(&j);
+        assert!(t.contains("be terse"));
+        assert!(t.contains("hello world"));
+
+        let p = json!({"prompt": "once upon a time"});
+        assert!(flatten_input_text(&p).contains("once upon a time"));
+    }
+
+    #[test]
+    fn flattens_array_multimodal_and_array_system() {
+        let j = json!({
+            "system": [{"type": "text", "text": "sys-a"}, {"type": "text", "text": "sys-b"}],
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part-1"},
+                    {"type": "image_url", "image_url": {"url": "x"}},
+                    {"type": "text", "text": "part-2"}
+                ]
+            }]
+        });
+        let t = flatten_input_text(&j);
+        for needle in ["sys-a", "sys-b", "part-1", "part-2"] {
+            assert!(t.contains(needle), "missing {needle} in {t:?}");
+        }
+        assert!(!t.contains("image_url"));
+    }
+}

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,8 +1,11 @@
-//! Shared request-routing helpers used by BOTH the native server and the
-//! Cloudflare Worker, so provider resolution and input flattening behave
-//! identically on every deployment shape.
+//! Shared request/response shaping used by BOTH the native server and the
+//! Cloudflare Worker, so provider resolution, input flattening, Nova Guard text
+//! transforms, and the Anthropic→OpenAI conversion behave identically on every
+//! deployment shape.
 
-use serde_json::Value;
+use serde_json::{json, Value};
+
+use crate::policy::{decision::Phase, PolicyEngine};
 
 /// Where an OpenAI-compatible request should be forwarded.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -102,10 +105,245 @@ pub fn flatten_input_text(json: &Value) -> String {
     out
 }
 
+/// Apply Nova Guard input transforms (redact/mask) to every text segment in the
+/// request body in place — string content, array-form (multimodal) content
+/// parts, array-form `system` blocks, and a plain `prompt`. Returns true if
+/// anything was mutated.
+///
+/// Uses the engine's transform-only path; the aggregate block decision is made
+/// separately over the flattened text, so blocking is not re-litigated per
+/// segment and cost/rate/token policies do not re-run here.
+pub fn apply_input_transforms(engine: &PolicyEngine, model: &str, json: &mut Value) -> bool {
+    let mut changed = false;
+    let transform = |s: &str| engine.apply_text_transforms(Phase::Input, model, s);
+
+    fn rewrite_string(
+        v: &mut Value,
+        transform: &dyn Fn(&str) -> Option<String>,
+        changed: &mut bool,
+    ) {
+        if let Value::String(s) = v {
+            if let Some(t) = transform(s) {
+                if &t != s {
+                    *v = Value::String(t);
+                    *changed = true;
+                }
+            }
+        }
+    }
+
+    fn rewrite_content(
+        v: &mut Value,
+        transform: &dyn Fn(&str) -> Option<String>,
+        changed: &mut bool,
+    ) {
+        match v {
+            Value::String(_) => rewrite_string(v, transform, changed),
+            Value::Array(parts) => {
+                for part in parts.iter_mut() {
+                    if let Some(text) = part.get_mut("text") {
+                        rewrite_string(text, transform, changed);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(prompt) = json.get_mut("prompt") {
+        rewrite_string(prompt, &transform, &mut changed);
+    }
+    if let Some(system) = json.get_mut("system") {
+        // Anthropic `system` may be a string or an array of text blocks.
+        rewrite_content(system, &transform, &mut changed);
+    }
+    if let Some(messages) = json.get_mut("messages").and_then(|m| m.as_array_mut()) {
+        for msg in messages.iter_mut() {
+            if let Some(content) = msg.get_mut("content") {
+                rewrite_content(content, &transform, &mut changed);
+            }
+        }
+    }
+
+    changed
+}
+
+/// Extract the assistant text from a provider response body, for the output-phase
+/// scan. Handles Anthropic (`content[].text`), Google/Gemini native
+/// (`candidates[].content.parts[].text`), and OpenAI-compatible
+/// (`choices[].message.content`).
+pub fn flatten_output_text(provider: &str, json: &Value) -> String {
+    match provider {
+        "anthropic" => json
+            .get("content")
+            .and_then(|c| c.as_array())
+            .map(|parts| {
+                parts
+                    .iter()
+                    .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default(),
+        "google" | "gemini" => json
+            .get("candidates")
+            .and_then(|c| c.as_array())
+            .map(|cands| {
+                cands
+                    .iter()
+                    .filter_map(|c| c.get("content").and_then(|ct| ct.get("parts")))
+                    .filter_map(|p| p.as_array())
+                    .flat_map(|parts| {
+                        parts
+                            .iter()
+                            .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default(),
+        // OpenAI / compatible
+        _ => json
+            .get("choices")
+            .and_then(|c| c.as_array())
+            .map(|choices| {
+                choices
+                    .iter()
+                    .filter_map(|c| {
+                        c.get("message")
+                            .and_then(|m| m.get("content"))
+                            .and_then(|c| c.as_str())
+                    })
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            })
+            .unwrap_or_default(),
+    }
+}
+
+/// Rewrite the first assistant text field with the transformed text (output-phase
+/// redaction). Best-effort for the common OpenAI/Anthropic shapes; returns true
+/// if it rewrote anything.
+pub fn rewrite_output_text(provider: &str, json: &mut Value, new_text: &str) -> bool {
+    match provider {
+        "anthropic" => {
+            if let Some(parts) = json.get_mut("content").and_then(|c| c.as_array_mut()) {
+                if let Some(first_text) = parts
+                    .iter_mut()
+                    .find(|p| p.get("text").map(|t| t.is_string()).unwrap_or(false))
+                {
+                    first_text["text"] = Value::String(new_text.to_string());
+                    return true;
+                }
+            }
+            false
+        }
+        _ => {
+            if let Some(choices) = json.get_mut("choices").and_then(|c| c.as_array_mut()) {
+                if let Some(first) = choices.first_mut() {
+                    if let Some(msg) = first.get_mut("message") {
+                        msg["content"] = Value::String(new_text.to_string());
+                        return true;
+                    }
+                }
+            }
+            false
+        }
+    }
+}
+
+/// Convert an Anthropic Messages API response into the OpenAI Chat Completions
+/// shape. `created_ts` is the unix-seconds timestamp for the `created` field
+/// (passed in because `chrono::Utc::now()` is unavailable on wasm32).
+pub fn transform_anthropic_to_openai_format(anthropic_response: Value, created_ts: i64) -> Value {
+    let content =
+        if let Some(content_array) = anthropic_response.get("content").and_then(|c| c.as_array()) {
+            let mut text = String::new();
+            for item in content_array {
+                if let Some(item_text) = item.get("text").and_then(|t| t.as_str()) {
+                    text.push_str(item_text);
+                }
+            }
+            text
+        } else {
+            anthropic_response
+                .get("content")
+                .and_then(|c| c.as_str())
+                .unwrap_or("")
+                .to_string()
+        };
+
+    let usage = {
+        let mut usage_map = json!({"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0});
+        if let Some(anthropic_usage) = anthropic_response.get("usage") {
+            if let Some(input_tokens) = anthropic_usage.get("input_tokens").and_then(|t| t.as_u64())
+            {
+                usage_map["prompt_tokens"] = json!(input_tokens);
+            }
+            if let Some(output_tokens) = anthropic_usage
+                .get("output_tokens")
+                .and_then(|t| t.as_u64())
+            {
+                usage_map["completion_tokens"] = json!(output_tokens);
+            }
+            let prompt_tokens = usage_map["prompt_tokens"].as_u64().unwrap_or(0);
+            let completion_tokens = usage_map["completion_tokens"].as_u64().unwrap_or(0);
+            usage_map["total_tokens"] = json!(prompt_tokens + completion_tokens);
+        }
+        usage_map
+    };
+
+    let finish_reason = match anthropic_response
+        .get("stop_reason")
+        .and_then(|r| r.as_str())
+    {
+        Some("end_turn") => "stop",
+        Some("max_tokens") => "length",
+        Some("stop_sequence") => "stop",
+        Some(reason) => reason,
+        None => "stop",
+    };
+
+    let mut transformed = json!({
+        "id": anthropic_response.get("id").unwrap_or(&Value::Null),
+        "object": "chat.completion",
+        "created": created_ts,
+        "model": anthropic_response.get("model").unwrap_or(&Value::Null),
+        "type": anthropic_response.get("type").unwrap_or(&json!("message")),
+        "role": anthropic_response.get("role").unwrap_or(&json!("assistant")),
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": anthropic_response.get("role").unwrap_or(&json!("assistant")),
+                "content": content
+            },
+            "finish_reason": finish_reason
+        }],
+        "usage": usage,
+        "system_fingerprint": format!("anthropic-{}", anthropic_response.get("model").and_then(|m| m.as_str()).unwrap_or("claude"))
+    });
+
+    if let Some(seed) = anthropic_response.get("seed") {
+        if let Some(choices) = transformed
+            .get_mut("choices")
+            .and_then(|c| c.as_array_mut())
+        {
+            for choice in choices {
+                if seed.is_number() {
+                    choice["seed"] = json!(seed.to_string());
+                } else {
+                    choice["seed"] = seed.clone();
+                }
+            }
+        }
+    }
+
+    transformed
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
     fn resolves_openai_compatible_providers() {
@@ -185,5 +423,80 @@ mod tests {
             assert!(t.contains(needle), "missing {needle} in {t:?}");
         }
         assert!(!t.contains("image_url"));
+    }
+
+    #[test]
+    fn flattens_output_for_openai_anthropic_and_gemini() {
+        let openai = json!({"choices": [{"message": {"content": "oai-out"}}]});
+        assert_eq!(flatten_output_text("openai", &openai), "oai-out");
+
+        let anthropic = json!({"content": [{"type": "text", "text": "ant-a"}, {"type": "text", "text": "ant-b"}]});
+        assert_eq!(flatten_output_text("anthropic", &anthropic), "ant-a\nant-b");
+
+        let gemini = json!({"candidates": [{"content": {"parts": [{"text": "gem-out"}]}}]});
+        assert_eq!(flatten_output_text("gemini", &gemini), "gem-out");
+    }
+
+    #[test]
+    fn rewrites_output_text_in_place() {
+        let mut openai =
+            json!({"choices": [{"message": {"role": "assistant", "content": "secret"}}]});
+        assert!(rewrite_output_text("openai", &mut openai, "[REDACTED]"));
+        assert_eq!(openai["choices"][0]["message"]["content"], "[REDACTED]");
+
+        let mut anthropic = json!({"content": [{"type": "text", "text": "secret"}]});
+        assert!(rewrite_output_text(
+            "anthropic",
+            &mut anthropic,
+            "[REDACTED]"
+        ));
+        assert_eq!(anthropic["content"][0]["text"], "[REDACTED]");
+
+        // Nothing to rewrite → false.
+        let mut empty = json!({"choices": []});
+        assert!(!rewrite_output_text("openai", &mut empty, "x"));
+    }
+
+    #[test]
+    fn anthropic_to_openai_maps_content_usage_finish_and_created() {
+        let anthropic = json!({
+            "id": "msg_1",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-4-5",
+            "content": [{"type": "text", "text": "Hello "}, {"type": "text", "text": "world"}],
+            "stop_reason": "max_tokens",
+            "usage": {"input_tokens": 5, "output_tokens": 2}
+        });
+        let out = transform_anthropic_to_openai_format(anthropic, 1_700_000_000);
+        assert_eq!(out["object"], "chat.completion");
+        assert_eq!(out["created"], 1_700_000_000);
+        assert_eq!(out["choices"][0]["message"]["content"], "Hello world");
+        assert_eq!(out["choices"][0]["finish_reason"], "length");
+        assert_eq!(out["usage"]["total_tokens"], 7);
+    }
+
+    #[test]
+    fn apply_input_transforms_redacts_via_engine() {
+        use crate::policy::config::PolicyBundle;
+        use crate::policy::engine::EngineOptions;
+
+        // A redact policy that masks the literal "secret" in the input phase,
+        // using a custom `redactWith` replacement.
+        let bundle = PolicyBundle::from_json_str(
+            r#"{"policies":[{"name":"redact-secret","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"sec","regex":"secret"}],"action":"redact","redactWith":"[MASKED]"}}]}"#,
+        )
+        .expect("bundle parses");
+        let engine = PolicyEngine::from_bundle(&bundle, EngineOptions::default());
+
+        let mut body = json!({
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": "my secret is here"}]
+        });
+        let changed = apply_input_transforms(&engine, "gpt-4o", &mut body);
+        assert!(changed, "expected redaction to mutate the body");
+        let content = body["messages"][0]["content"].as_str().unwrap();
+        assert!(content.contains("[MASKED]"), "got: {content}");
+        assert!(!content.contains("secret"));
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -380,6 +380,90 @@ pub fn transform_anthropic_to_openai_format(anthropic_response: Value, created_t
     transformed
 }
 
+/// Convert an OpenAI chat-completions body into the AWS Bedrock **Converse** API
+/// request shape. Mirrors the native `BedrockProvider::transform_request_body`
+/// (defaults: maxTokens 1000, temperature 0.7, topP 1.0).
+pub fn openai_to_bedrock_converse(body: &Value) -> Value {
+    // Already Converse-shaped → pass through.
+    if body.get("inferenceConfig").is_some() {
+        return body.clone();
+    }
+
+    let messages = body.get("messages").and_then(|m| m.as_array());
+    let transformed: Vec<Value> = messages
+        .map(|arr| {
+            arr.iter()
+                .map(|msg| {
+                    let content = msg
+                        .get("content")
+                        .and_then(|c| c.as_str())
+                        .unwrap_or_default();
+                    json!({
+                        "role": msg.get("role").and_then(|r| r.as_str()).unwrap_or("user"),
+                        "content": [{ "text": content }],
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "messages": transformed,
+        "inferenceConfig": {
+            "maxTokens": body.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(1000),
+            "temperature": body.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7),
+            "topP": body.get("top_p").and_then(|v| v.as_f64()).unwrap_or(1.0),
+        }
+    })
+}
+
+/// Convert an AWS Bedrock **Converse** API response into OpenAI Chat Completions
+/// shape. Mirrors the native `BedrockProvider::transform_bedrock_to_openai_format`.
+/// `created_ts` is passed in (chrono is unavailable on wasm32).
+pub fn bedrock_converse_to_openai(resp: &Value, model: &str, created_ts: i64) -> Value {
+    let content = resp
+        .get("output")
+        .and_then(|o| o.get("message"))
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_array())
+        .and_then(|a| a.first())
+        .and_then(|f| f.get("text"))
+        .and_then(|t| t.as_str())
+        .unwrap_or_default();
+
+    let usage = resp.get("usage");
+    let tok = |k: &str| {
+        usage
+            .and_then(|u| u.get(k))
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0)
+    };
+
+    let finish_reason = match resp.get("stopReason").and_then(|s| s.as_str()) {
+        Some("end_turn") => "stop",
+        Some("max_tokens") => "length",
+        Some("stop_sequence") => "stop",
+        _ => "stop",
+    };
+
+    json!({
+        "id": format!("chatcmpl-bedrock-{created_ts}"),
+        "object": "chat.completion",
+        "created": created_ts,
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": { "role": "assistant", "content": content },
+            "finish_reason": finish_reason,
+        }],
+        "usage": {
+            "prompt_tokens": tok("inputTokens"),
+            "completion_tokens": tok("outputTokens"),
+            "total_tokens": tok("totalTokens"),
+        }
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -563,5 +647,42 @@ mod tests {
         let content = body["messages"][0]["content"].as_str().unwrap();
         assert!(content.contains("[MASKED]"), "got: {content}");
         assert!(!content.contains("secret"));
+    }
+
+    #[test]
+    fn openai_to_bedrock_converse_shapes_messages_and_config() {
+        let body = json!({
+            "model": "amazon.titan-text-premier-v1:0",
+            "max_tokens": 256,
+            "temperature": 0.2,
+            "messages": [{"role": "user", "content": "hello"}]
+        });
+        let out = openai_to_bedrock_converse(&body);
+        assert_eq!(out["messages"][0]["role"], "user");
+        assert_eq!(out["messages"][0]["content"][0]["text"], "hello");
+        assert_eq!(out["inferenceConfig"]["maxTokens"], 256);
+        assert_eq!(out["inferenceConfig"]["temperature"], 0.2);
+        assert_eq!(out["inferenceConfig"]["topP"], 1.0); // default
+                                                         // Already-Converse bodies pass through unchanged.
+        let passthrough = json!({"messages": [], "inferenceConfig": {"maxTokens": 1}});
+        assert_eq!(openai_to_bedrock_converse(&passthrough), passthrough);
+    }
+
+    #[test]
+    fn bedrock_converse_to_openai_maps_content_usage_and_finish() {
+        let resp = json!({
+            "output": {"message": {"content": [{"text": "hi there"}]}},
+            "stopReason": "max_tokens",
+            "usage": {"inputTokens": 7, "outputTokens": 3, "totalTokens": 10}
+        });
+        let out =
+            bedrock_converse_to_openai(&resp, "amazon.titan-text-premier-v1:0", 1_700_000_000);
+        assert_eq!(out["object"], "chat.completion");
+        assert_eq!(out["created"], 1_700_000_000);
+        assert_eq!(out["choices"][0]["message"]["content"], "hi there");
+        assert_eq!(out["choices"][0]["finish_reason"], "length");
+        assert_eq!(out["usage"]["prompt_tokens"], 7);
+        assert_eq!(out["usage"]["completion_tokens"], 3);
+        assert_eq!(out["usage"]["total_tokens"], 10);
     }
 }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -221,35 +221,74 @@ pub fn flatten_output_text(provider: &str, json: &Value) -> String {
     }
 }
 
-/// Rewrite the first assistant text field with the transformed text (output-phase
-/// redaction). Best-effort for the common OpenAI/Anthropic shapes; returns true
-/// if it rewrote anything.
-pub fn rewrite_output_text(provider: &str, json: &mut Value, new_text: &str) -> bool {
+/// Apply Nova Guard output transforms (redact/mask) to EVERY assistant text
+/// segment in a response body in place — every OpenAI `choices[].message.content`,
+/// every Anthropic `content[].text`, and every Gemini
+/// `candidates[].content.parts[].text`. Mirrors [`flatten_output_text`]'s full
+/// traversal so multi-choice / multi-block responses can't leak unredacted text.
+/// Returns true if anything was mutated.
+pub fn apply_output_transforms(
+    engine: &PolicyEngine,
+    model: &str,
+    provider: &str,
+    json: &mut Value,
+) -> bool {
+    let mut changed = false;
+    let transform = |s: &str| engine.apply_text_transforms(Phase::Output, model, s);
+
+    fn rewrite_str(v: &mut Value, transform: &dyn Fn(&str) -> Option<String>, changed: &mut bool) {
+        if let Value::String(s) = v {
+            if let Some(t) = transform(s) {
+                if &t != s {
+                    *v = Value::String(t);
+                    *changed = true;
+                }
+            }
+        }
+    }
+
     match provider {
         "anthropic" => {
             if let Some(parts) = json.get_mut("content").and_then(|c| c.as_array_mut()) {
-                if let Some(first_text) = parts
-                    .iter_mut()
-                    .find(|p| p.get("text").map(|t| t.is_string()).unwrap_or(false))
-                {
-                    first_text["text"] = Value::String(new_text.to_string());
-                    return true;
-                }
-            }
-            false
-        }
-        _ => {
-            if let Some(choices) = json.get_mut("choices").and_then(|c| c.as_array_mut()) {
-                if let Some(first) = choices.first_mut() {
-                    if let Some(msg) = first.get_mut("message") {
-                        msg["content"] = Value::String(new_text.to_string());
-                        return true;
+                for part in parts.iter_mut() {
+                    if let Some(text) = part.get_mut("text") {
+                        rewrite_str(text, &transform, &mut changed);
                     }
                 }
             }
-            false
+        }
+        "google" | "gemini" => {
+            if let Some(cands) = json.get_mut("candidates").and_then(|c| c.as_array_mut()) {
+                for cand in cands.iter_mut() {
+                    if let Some(parts) = cand
+                        .get_mut("content")
+                        .and_then(|ct| ct.get_mut("parts"))
+                        .and_then(|p| p.as_array_mut())
+                    {
+                        for part in parts.iter_mut() {
+                            if let Some(text) = part.get_mut("text") {
+                                rewrite_str(text, &transform, &mut changed);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        // OpenAI / compatible
+        _ => {
+            if let Some(choices) = json.get_mut("choices").and_then(|c| c.as_array_mut()) {
+                for choice in choices.iter_mut() {
+                    if let Some(content) =
+                        choice.get_mut("message").and_then(|m| m.get_mut("content"))
+                    {
+                        rewrite_str(content, &transform, &mut changed);
+                    }
+                }
+            }
         }
     }
+
+    changed
 }
 
 /// Convert an Anthropic Messages API response into the OpenAI Chat Completions
@@ -438,23 +477,49 @@ mod tests {
     }
 
     #[test]
-    fn rewrites_output_text_in_place() {
-        let mut openai =
-            json!({"choices": [{"message": {"role": "assistant", "content": "secret"}}]});
-        assert!(rewrite_output_text("openai", &mut openai, "[REDACTED]"));
-        assert_eq!(openai["choices"][0]["message"]["content"], "[REDACTED]");
+    fn apply_output_transforms_redacts_every_segment() {
+        use crate::policy::config::PolicyBundle;
+        use crate::policy::engine::EngineOptions;
 
-        let mut anthropic = json!({"content": [{"type": "text", "text": "secret"}]});
-        assert!(rewrite_output_text(
-            "anthropic",
-            &mut anthropic,
-            "[REDACTED]"
+        let bundle = PolicyBundle::from_json_str(
+            r#"{"policies":[{"name":"redact-out","type":"regex_match","mode":"enforce","config":{"phase":"output","patterns":[{"name":"s","regex":"secret"}],"action":"redact","redactWith":"[X]"}}]}"#,
+        )
+        .expect("bundle parses");
+        let engine = PolicyEngine::from_bundle(&bundle, EngineOptions::default());
+
+        // OpenAI: BOTH choices must be redacted (regression: only the first was).
+        let mut openai = json!({"choices": [
+            {"message": {"role": "assistant", "content": "secret one"}},
+            {"message": {"role": "assistant", "content": "secret two"}}
+        ]});
+        assert!(apply_output_transforms(
+            &engine,
+            "gpt-4o",
+            "openai",
+            &mut openai
         ));
-        assert_eq!(anthropic["content"][0]["text"], "[REDACTED]");
+        assert_eq!(openai["choices"][0]["message"]["content"], "[X] one");
+        assert_eq!(openai["choices"][1]["message"]["content"], "[X] two");
 
-        // Nothing to rewrite → false.
-        let mut empty = json!({"choices": []});
-        assert!(!rewrite_output_text("openai", &mut empty, "x"));
+        // Anthropic: every text block.
+        let mut anthropic = json!({"content": [
+            {"type": "text", "text": "secret a"},
+            {"type": "text", "text": "secret b"}
+        ]});
+        assert!(apply_output_transforms(
+            &engine,
+            "claude",
+            "anthropic",
+            &mut anthropic
+        ));
+        assert_eq!(anthropic["content"][0]["text"], "[X] a");
+        assert_eq!(anthropic["content"][1]["text"], "[X] b");
+
+        // No match → false.
+        let mut clean = json!({"choices": [{"message": {"content": "all clear"}}]});
+        assert!(!apply_output_transforms(
+            &engine, "gpt-4o", "openai", &mut clean
+        ));
     }
 
     #[test]

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -389,46 +389,77 @@ pub fn openai_to_bedrock_converse(body: &Value) -> Value {
         return body.clone();
     }
 
-    let messages = body.get("messages").and_then(|m| m.as_array());
-    let transformed: Vec<Value> = messages
-        .map(|arr| {
-            arr.iter()
-                .map(|msg| {
-                    let content = msg
-                        .get("content")
-                        .and_then(|c| c.as_str())
-                        .unwrap_or_default();
-                    json!({
-                        "role": msg.get("role").and_then(|r| r.as_str()).unwrap_or("user"),
-                        "content": [{ "text": content }],
-                    })
-                })
-                .collect()
-        })
-        .unwrap_or_default();
-
-    json!({
-        "messages": transformed,
-        "inferenceConfig": {
-            "maxTokens": body.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(1000),
-            "temperature": body.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7),
-            "topP": body.get("top_p").and_then(|v| v.as_f64()).unwrap_or(1.0),
+    // Extract a message's text from string OR array-of-parts content.
+    fn content_text(msg: &Value) -> String {
+        match msg.get("content") {
+            Some(Value::String(s)) => s.clone(),
+            Some(Value::Array(parts)) => parts
+                .iter()
+                .filter_map(|p| p.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join(""),
+            _ => String::new(),
         }
-    })
+    }
+
+    // Converse keeps `system` separate and only allows user/assistant roles in
+    // `messages`; route `system` entries to the top-level `system` field so they
+    // are not dropped or rejected.
+    let mut messages = Vec::new();
+    let mut system = Vec::new();
+    if let Some(arr) = body.get("messages").and_then(|m| m.as_array()) {
+        for msg in arr {
+            let role = msg.get("role").and_then(|r| r.as_str()).unwrap_or("user");
+            let text = content_text(msg);
+            if role == "system" {
+                system.push(json!({ "text": text }));
+            } else {
+                messages.push(json!({ "role": role, "content": [{ "text": text }] }));
+            }
+        }
+    }
+
+    let mut inference = json!({
+        "maxTokens": body.get("max_tokens").and_then(|v| v.as_u64()).unwrap_or(1000),
+        "temperature": body.get("temperature").and_then(|v| v.as_f64()).unwrap_or(0.7),
+        "topP": body.get("top_p").and_then(|v| v.as_f64()).unwrap_or(1.0),
+    });
+    // OpenAI `stop` (string or array) → Converse `inferenceConfig.stopSequences`.
+    match body.get("stop") {
+        Some(Value::String(s)) => inference["stopSequences"] = json!([s]),
+        Some(Value::Array(a)) => {
+            let seqs: Vec<&str> = a.iter().filter_map(|v| v.as_str()).collect();
+            if !seqs.is_empty() {
+                inference["stopSequences"] = json!(seqs);
+            }
+        }
+        _ => {}
+    }
+
+    let mut out = json!({ "messages": messages, "inferenceConfig": inference });
+    if !system.is_empty() {
+        out["system"] = Value::Array(system);
+    }
+    out
 }
 
 /// Convert an AWS Bedrock **Converse** API response into OpenAI Chat Completions
 /// shape. Mirrors the native `BedrockProvider::transform_bedrock_to_openai_format`.
 /// `created_ts` is passed in (chrono is unavailable on wasm32).
 pub fn bedrock_converse_to_openai(resp: &Value, model: &str, created_ts: i64) -> Value {
+    // Concatenate ALL text blocks (Converse may return several), not just the
+    // first, so multi-block responses are not silently truncated.
     let content = resp
         .get("output")
         .and_then(|o| o.get("message"))
         .and_then(|m| m.get("content"))
         .and_then(|c| c.as_array())
-        .and_then(|a| a.first())
-        .and_then(|f| f.get("text"))
-        .and_then(|t| t.as_str())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|b| b.get("text").and_then(|t| t.as_str()))
+                .collect::<Vec<_>>()
+                .join("")
+        })
         .unwrap_or_default();
 
     let usage = resp.get("usage");
@@ -441,8 +472,10 @@ pub fn bedrock_converse_to_openai(resp: &Value, model: &str, created_ts: i64) ->
 
     let finish_reason = match resp.get("stopReason").and_then(|s| s.as_str()) {
         Some("end_turn") => "stop",
-        Some("max_tokens") => "length",
+        Some("max_tokens") | Some("model_context_window_exceeded") => "length",
         Some("stop_sequence") => "stop",
+        // Surface safety stops distinctly instead of as a normal "stop".
+        Some("content_filtered") | Some("guardrail_intervened") => "content_filter",
         _ => "stop",
     };
 
@@ -684,5 +717,47 @@ mod tests {
         assert_eq!(out["usage"]["prompt_tokens"], 7);
         assert_eq!(out["usage"]["completion_tokens"], 3);
         assert_eq!(out["usage"]["total_tokens"], 10);
+    }
+
+    #[test]
+    fn openai_to_bedrock_converse_handles_system_array_content_and_stop() {
+        let body = json!({
+            "model": "amazon.nova-micro-v1:0",
+            "stop": ["END", "STOP"],
+            "messages": [
+                {"role": "system", "content": "be terse"},
+                {"role": "user", "content": [
+                    {"type": "text", "text": "part-1"},
+                    {"type": "image_url", "image_url": {"url": "x"}},
+                    {"type": "text", "text": " part-2"}
+                ]}
+            ]
+        });
+        let out = openai_to_bedrock_converse(&body);
+        // system routed to the top-level field, NOT into messages.
+        assert_eq!(out["system"][0]["text"], "be terse");
+        assert_eq!(out["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(out["messages"][0]["role"], "user");
+        // array (multimodal) content text is preserved, not dropped to empty.
+        assert_eq!(out["messages"][0]["content"][0]["text"], "part-1 part-2");
+        // stop → stopSequences.
+        assert_eq!(
+            out["inferenceConfig"]["stopSequences"],
+            json!(["END", "STOP"])
+        );
+    }
+
+    #[test]
+    fn bedrock_converse_aggregates_blocks_and_maps_safety_stops() {
+        let resp = json!({
+            "output": {"message": {"content": [{"text": "a"}, {"text": "b"}, {"text": "c"}]}},
+            "stopReason": "guardrail_intervened",
+            "usage": {"inputTokens": 1, "outputTokens": 1, "totalTokens": 2}
+        });
+        let out = bedrock_converse_to_openai(&resp, "m", 1);
+        // ALL content blocks concatenated (regression: only the first was kept).
+        assert_eq!(out["choices"][0]["message"]["content"], "abc");
+        // safety stop surfaced distinctly.
+        assert_eq!(out["choices"][0]["finish_reason"], "content_filter");
     }
 }

--- a/src/sigv4.rs
+++ b/src/sigv4.rs
@@ -1,0 +1,183 @@
+//! AWS Signature Version 4 signing — shared, but used only by the Cloudflare
+//! Worker (wasm32).
+//!
+//! The native server signs Bedrock requests with `aws-sigv4` (which pulls
+//! `ring`/`aws-lc` and does not build for `wasm32-unknown-unknown`). On the edge
+//! we implement the SigV4 algorithm directly with pure-Rust `sha2` + `hmac`
+//! (both build for wasm), which is simpler and more reliable than the async Web
+//! Crypto `SubtleCrypto` API. The module is compiled on both targets so the
+//! algorithm is unit-tested in native CI.
+//!
+//! Unlike the native path, this supports **temporary credentials**: an
+//! `x-amz-security-token` is signed + sent when a session token is present.
+
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn hmac(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut mac = HmacSha256::new_from_slice(key).expect("HMAC accepts any key length");
+    mac.update(data);
+    mac.finalize().into_bytes().to_vec()
+}
+
+fn hex(bytes: &[u8]) -> String {
+    use core::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+fn sha256_hex(data: &[u8]) -> String {
+    hex(&Sha256::digest(data))
+}
+
+/// The headers a caller must attach to the outbound request after signing.
+pub struct SignedHeaders {
+    pub authorization: String,
+    pub amz_date: String,
+    pub security_token: Option<String>,
+}
+
+/// Compute the SigV4 `Authorization` header for a request.
+///
+/// `canonical_uri` must already be path-encoded (e.g. model ARNs with `/`
+/// escaped to `%2F`). `query` is the canonical query string (empty for Bedrock
+/// Converse). `amz_date` is `YYYYMMDDTHHMMSSZ`, `datestamp` is `YYYYMMDD`. The
+/// signed headers are exactly `content-type;host;x-amz-date[;x-amz-security-token]`.
+#[allow(clippy::too_many_arguments)]
+pub fn sign(
+    method: &str,
+    host: &str,
+    canonical_uri: &str,
+    query: &str,
+    body: &[u8],
+    access_key: &str,
+    secret_key: &str,
+    session_token: Option<&str>,
+    region: &str,
+    service: &str,
+    amz_date: &str,
+    datestamp: &str,
+) -> SignedHeaders {
+    let payload_hash = sha256_hex(body);
+
+    // Canonical headers MUST be sorted by lowercase name:
+    // content-type < host < x-amz-date < x-amz-security-token.
+    let mut canonical_headers =
+        format!("content-type:application/json\nhost:{host}\nx-amz-date:{amz_date}\n");
+    let mut signed_headers = String::from("content-type;host;x-amz-date");
+    if let Some(token) = session_token {
+        canonical_headers.push_str(&format!("x-amz-security-token:{token}\n"));
+        signed_headers.push_str(";x-amz-security-token");
+    }
+
+    let canonical_request = format!(
+        "{method}\n{canonical_uri}\n{query}\n{canonical_headers}\n{signed_headers}\n{payload_hash}"
+    );
+
+    let scope = format!("{datestamp}/{region}/{service}/aws4_request");
+    let string_to_sign = format!(
+        "AWS4-HMAC-SHA256\n{amz_date}\n{scope}\n{}",
+        sha256_hex(canonical_request.as_bytes())
+    );
+
+    // Derive the signing key (HMAC chain) and sign.
+    let k_date = hmac(format!("AWS4{secret_key}").as_bytes(), datestamp.as_bytes());
+    let k_region = hmac(&k_date, region.as_bytes());
+    let k_service = hmac(&k_region, service.as_bytes());
+    let k_signing = hmac(&k_service, b"aws4_request");
+    let signature = hex(&hmac(&k_signing, string_to_sign.as_bytes()));
+
+    let authorization = format!(
+        "AWS4-HMAC-SHA256 Credential={access_key}/{scope}, SignedHeaders={signed_headers}, Signature={signature}"
+    );
+
+    SignedHeaders {
+        authorization,
+        amz_date: amz_date.to_string(),
+        security_token: session_token.map(String::from),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hmac_sha256_matches_rfc4231_test_case_2() {
+        // RFC 4231 §4.3 Test Case 2 — authoritative HMAC-SHA256 vector. Pins our
+        // HMAC primitive (the SigV4 signing-key chain) to the reference output.
+        let mac = hmac(b"Jefe", b"what do ya want for nothing?");
+        assert_eq!(
+            hex(&mac),
+            "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"
+        );
+    }
+
+    #[test]
+    fn sha256_hex_of_empty_is_known() {
+        // The universal SHA-256 of the empty string (used as the SigV4 payload
+        // hash for empty bodies).
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sign_includes_security_token_when_present() {
+        let out = sign(
+            "POST",
+            "bedrock-runtime.us-east-1.amazonaws.com",
+            "/model/amazon.titan/converse",
+            "",
+            b"{}",
+            "AKID",
+            "secret",
+            Some("session-token-123"),
+            "us-east-1",
+            "bedrock",
+            "20240101T000000Z",
+            "20240101",
+        );
+        assert!(out.authorization.starts_with(
+            "AWS4-HMAC-SHA256 Credential=AKID/20240101/us-east-1/bedrock/aws4_request"
+        ));
+        assert!(out
+            .authorization
+            .contains("SignedHeaders=content-type;host;x-amz-date;x-amz-security-token"));
+        assert_eq!(out.security_token.as_deref(), Some("session-token-123"));
+    }
+
+    #[test]
+    fn sign_is_deterministic_and_body_sensitive() {
+        let args = |body: &'static [u8]| {
+            sign(
+                "POST",
+                "bedrock-runtime.us-east-1.amazonaws.com",
+                "/model/m/converse",
+                "",
+                body,
+                "AKID",
+                "secret",
+                None,
+                "us-east-1",
+                "bedrock",
+                "20240101T000000Z",
+                "20240101",
+            )
+            .authorization
+        };
+        assert_eq!(args(b"{}"), args(b"{}"), "same inputs → same signature");
+        assert_ne!(
+            args(b"{}"),
+            args(b"{\"a\":1}"),
+            "body change → signature change"
+        );
+        assert!(!args(b"{}").contains("x-amz-security-token"));
+    }
+}

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -8,12 +8,12 @@
 //! `reqwest`/`tokio`).
 //!
 //! Parity with the native server: same provider routing, same `x-provider`
-//! contract, same Nova Guard input/output decisions + redaction, the same block
-//! response modes (`NOVEUM_GUARD_BLOCK_RESPONSE_MODE`), and the same
-//! Anthropic→OpenAI response conversion. Streaming responses pass through
-//! without output‑phase enforcement (the documented v1 limitation, identical to
-//! native). Non‑JSON `/v1/*` bodies are forwarded byte‑for‑byte. Bedrock (AWS
-//! SigV4 via Web Crypto) lands in a later phase.
+//! contract, header pass‑through, query pass‑through, same Nova Guard
+//! input/output decisions + redaction, the same block response modes
+//! (`NOVEUM_GUARD_BLOCK_RESPONSE_MODE`), and the same Anthropic→OpenAI response
+//! conversion. Streaming responses pass through without output‑phase enforcement
+//! (the documented v1 limitation, identical to native). Non‑JSON `/v1/*` bodies
+//! are forwarded byte‑for‑byte. Bedrock (AWS SigV4 via Web Crypto) lands later.
 
 use futures_util::StreamExt;
 use serde_json::{json, Value};
@@ -31,6 +31,26 @@ use crate::routing::{
 /// responses pass through uninspected (matches native; avoids OOM on the
 /// 128 MB isolate).
 const MAX_BODY: usize = 8 * 1024 * 1024;
+
+/// Request headers we never forward upstream: hop-by-hop, length/encoding (the
+/// runtime recomputes them and we send a decoded body), and our routing header.
+/// `accept-encoding` is dropped so the upstream returns an inspectable
+/// (uncompressed) body, matching native reqwest's auto-decode behavior.
+const REQUEST_SKIP_HEADERS: &[&str] = &[
+    "host",
+    "content-length",
+    "content-encoding",
+    "accept-encoding",
+    "connection",
+    "transfer-encoding",
+    "keep-alive",
+    "x-provider",
+];
+
+/// Response headers we drop when re-emitting a buffered/transformed body (its
+/// length and encoding change); everything else (x-request-id, rate-limit, …)
+/// is preserved.
+const RESPONSE_SKIP_HEADERS: &[&str] = &["content-length", "content-encoding"];
 
 /// Build the Nova Guard engine from an in‑memory bundle.
 ///
@@ -74,6 +94,19 @@ fn build_engine(env: &Env) -> PolicyEngine {
     PolicyEngine::from_bundle(&bundle, opts)
 }
 
+/// Copy `src` headers into a fresh `Headers`, skipping any whose (lowercased)
+/// name is in `skip`.
+fn copy_headers_excluding(src: &Headers, skip: &[&str]) -> Result<Headers> {
+    let out = Headers::new();
+    for (k, v) in src.entries() {
+        if skip.contains(&k.to_ascii_lowercase().as_str()) {
+            continue;
+        }
+        out.set(&k, &v)?;
+    }
+    Ok(out)
+}
+
 /// Build a Nova Guard block response in the engine's configured mode, using the
 /// SHARED body/status builders so it is byte-identical to the native server.
 fn guard_block_response(
@@ -112,8 +145,44 @@ async fn read_body_capped(resp: &mut Response) -> core::result::Result<Vec<u8>, 
     Ok(buf)
 }
 
+/// Apply permissive CORS headers, matching the native `CorsLayer` (any origin /
+/// method / header). Works on responses we construct (mutable headers) and on
+/// pass-through responses re-wrapped by [`passthrough`].
+fn apply_cors(resp: Response) -> Response {
+    let h = resp.headers();
+    let _ = h.set("access-control-allow-origin", "*");
+    let _ = h.set("access-control-allow-methods", "*");
+    let _ = h.set("access-control-allow-headers", "*");
+    let _ = h.set("access-control-max-age", "3600");
+    resp
+}
+
+/// Re-wrap an upstream `Fetch` response so its headers become mutable (the raw
+/// Fetch response has an immutable header set). The body is re-streamed lazily —
+/// no buffering — so SSE/streaming pass-through is preserved. This lets the
+/// outer CORS layer attach headers even on the transparent proxy path.
+fn passthrough(mut resp: Response) -> Result<Response> {
+    let status = resp.status_code();
+    // Drop length/encoding: `from_stream` re-frames the body (chunked), so a
+    // copied Content-Length would be stale, and the bytes are already decoded.
+    let headers = copy_headers_excluding(resp.headers(), RESPONSE_SKIP_HEADERS)?;
+    let stream = resp.stream()?;
+    Ok(Response::from_stream(stream)?
+        .with_headers(headers)
+        .with_status(status))
+}
+
 #[event(fetch)]
-async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
+async fn fetch(req: Request, env: Env, ctx: Context) -> Result<Response> {
+    // CORS preflight — mirror the native permissive CorsLayer.
+    if req.method() == Method::Options {
+        return Ok(apply_cors(Response::empty()?.with_status(204)));
+    }
+    let resp = handle(req, env, ctx).await?;
+    Ok(apply_cors(resp))
+}
+
+async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
     let path = req.path();
 
     if path == "/health" {
@@ -143,6 +212,12 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         );
     }
 
+    // Preserve the query string (native forwards it).
+    let query = req
+        .url()
+        .ok()
+        .and_then(|u| u.query().map(|q| q.to_string()));
+
     // Only JSON bodies are parsed/guarded/transformed. Non-JSON (multipart,
     // binary) bodies are forwarded byte-for-byte, like the native proxy.
     let is_json_req = req
@@ -157,9 +232,12 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
     let guard_active = engine.is_enabled() && engine.active_policy_count() > 0;
     let block_mode = engine.block_mode();
 
-    // Read the raw request body once (so non-JSON forwards unchanged).
+    // Read the raw request body once.
     let body_bytes = req.bytes().await.unwrap_or_default();
-    let mut body_json: Option<Value> = if is_json_req {
+
+    // Parse JSON only when we actually need to inspect it (guard on). A
+    // transparent proxy forwards the original bytes byte-for-byte.
+    let mut body_json: Option<Value> = if guard_active && is_json_req {
         serde_json::from_slice(&body_bytes).ok()
     } else {
         None
@@ -172,6 +250,7 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .to_string();
 
     // --- Nova Guard input phase (block, then redact/mask transforms) ---
+    let mut redacted = false;
     if guard_active {
         if let Some(j) = &body_json {
             let input_text = flatten_input_text(j);
@@ -181,43 +260,40 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
             }
         }
         if let Some(j) = body_json.as_mut() {
-            apply_input_transforms(&engine, &model, j);
+            redacted = apply_input_transforms(&engine, &model, j);
         }
     }
 
-    // --- Build the outbound request (provider-specific routing/auth) ---
-    let (url, out_headers) = if is_anthropic {
-        let headers = Headers::new();
-        headers.set("content-type", "application/json")?;
-        headers.set("anthropic-version", "2023-06-01")?;
+    // --- Build the outbound request (forward client headers + provider auth) ---
+    let out_headers = copy_headers_excluding(req.headers(), REQUEST_SKIP_HEADERS)?;
+    let url = if is_anthropic {
+        // Anthropic uses x-api-key + anthropic-version, not Bearer auth.
+        out_headers.delete("authorization")?;
+        out_headers.set("anthropic-version", "2023-06-01")?;
         if let Ok(Some(auth)) = req.headers().get("authorization") {
-            let key = auth.trim_start_matches("Bearer ").trim();
-            headers.set("x-api-key", key)?;
+            out_headers.set("x-api-key", auth.trim_start_matches("Bearer ").trim())?;
         }
-        ("https://api.anthropic.com/v1/messages".to_string(), headers)
+        "https://api.anthropic.com/v1/messages".to_string()
     } else {
         let route = route.expect("checked above");
-        let headers = Headers::new();
-        headers.set("content-type", "application/json")?;
-        if let Ok(Some(auth)) = req.headers().get("authorization") {
-            headers.set("authorization", &auth)?;
+        let base = upstream_url(&route, &path);
+        match &query {
+            Some(q) => format!("{base}?{q}"),
+            None => base,
         }
-        (upstream_url(&route, &path), headers)
     };
 
-    // Forward the (possibly redacted) JSON as a string, or the original bytes
-    // verbatim for non-JSON requests.
+    // Forward the redacted JSON (re-serialized) or the original bytes verbatim.
     let mut init = RequestInit::new();
     init.with_method(Method::Post).with_headers(out_headers);
-    match &body_json {
-        Some(j) => {
+    if redacted {
+        if let Some(j) = &body_json {
             init.with_body(Some(serde_json::to_string(j).unwrap_or_default().into()));
         }
-        None => {
-            let arr = js_sys::Uint8Array::new_with_length(body_bytes.len() as u32);
-            arr.copy_from(&body_bytes);
-            init.with_body(Some(arr.into()));
-        }
+    } else {
+        let arr = js_sys::Uint8Array::new_with_length(body_bytes.len() as u32);
+        arr.copy_from(&body_bytes);
+        init.with_body(Some(arr.into()));
     }
     let out_req = Request::new_with_init(&url, &init)?;
     let mut resp = Fetch::Request(out_req).send().await?;
@@ -234,13 +310,13 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
     // Streaming passes through untouched (matches native v1; Anthropic SSE stays
     // in Anthropic shape, exactly like the native server).
     if is_stream {
-        return Ok(resp);
+        return passthrough(resp);
     }
 
     // Non-streaming: only buffer when we must transform (Anthropic) or run the
     // output phase; otherwise stream the upstream response straight back.
     if !is_anthropic && !guard_active {
-        return Ok(resp);
+        return passthrough(resp);
     }
 
     // Fast path: a declared length over the cap → pass through unbuffered.
@@ -251,10 +327,13 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .flatten()
         .and_then(|v| v.parse::<usize>().ok());
     if matches!(declared, Some(n) if n > MAX_BODY) {
-        return Ok(resp);
+        return passthrough(resp);
     }
 
     let status = resp.status_code();
+    // Preserve upstream response headers (x-request-id, rate-limit, …) on the
+    // re-emitted body; drop length/encoding since the body changes.
+    let resp_headers = copy_headers_excluding(resp.headers(), RESPONSE_SKIP_HEADERS)?;
 
     // Read with a hard cap (covers chunked / missing Content-Length).
     let bytes = match read_body_capped(&mut resp).await {
@@ -272,8 +351,12 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
 
     let mut out_json: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
-        // Not JSON — return the buffered bytes unchanged with the upstream status.
-        Err(_) => return Ok(Response::from_bytes(bytes)?.with_status(status)),
+        // Not JSON — return the buffered bytes unchanged, preserving headers/status.
+        Err(_) => {
+            return Ok(Response::from_bytes(bytes)?
+                .with_headers(resp_headers)
+                .with_status(status))
+        }
     };
 
     // Anthropic → OpenAI shape for parity (only successful responses carry the
@@ -304,5 +387,8 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         }
     }
 
-    Ok(Response::from_json(&out_json)?.with_status(status))
+    let out_bytes = serde_json::to_vec(&out_json).unwrap_or_default();
+    Ok(Response::from_bytes(out_bytes)?
+        .with_headers(resp_headers)
+        .with_status(status))
 }

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -2,17 +2,25 @@
 //!
 //! This is the `wasm32` entry point: a `#[event(fetch)]` handler that runs the
 //! gateway as a true per‑PoP edge Worker. It reuses the **shared Nova Guard
-//! engine** ([`crate::policy`]) for input enforcement, then proxies the request
-//! to the upstream provider via the platform `Fetch` API (no `reqwest`/`tokio`).
+//! engine** ([`crate::policy`]) and the shared request/response shaping
+//! ([`crate::routing`]) for full parity with the native server, then proxies the
+//! request to the upstream provider via the platform `Fetch` API (no
+//! `reqwest`/`tokio`).
 //!
 //! Parity with the native server: same provider routing, same `x-provider`
-//! contract, same Nova Guard decisions. Bedrock (AWS SigV4 via Web Crypto) and
-//! streaming output‑phase enforcement land in later phases.
+//! contract, same Nova Guard input/output decisions + redaction, and the same
+//! Anthropic→OpenAI response conversion. Streaming responses pass through
+//! without output‑phase enforcement (the documented v1 limitation, identical to
+//! native). Bedrock (AWS SigV4 via Web Crypto) lands in a later phase.
 
+use serde_json::{json, Value};
 use worker::*;
 
 use crate::policy::{decision::Phase, PolicyEngine};
-use crate::routing::{flatten_input_text, resolve_provider, upstream_url};
+use crate::routing::{
+    apply_input_transforms, flatten_input_text, flatten_output_text, resolve_provider,
+    rewrite_output_text, transform_anthropic_to_openai_format, upstream_url,
+};
 
 /// Build the Nova Guard engine from an in‑memory bundle.
 ///
@@ -48,12 +56,31 @@ fn build_engine(env: &Env) -> PolicyEngine {
     PolicyEngine::from_bundle(&bundle, opts)
 }
 
+/// Nova Guard block envelope (OpenAI-style error). Returned with HTTP 200 +
+/// `x-noveum-guard-blocked` so clients can detect a guard block distinctly from
+/// an upstream error.
+fn guard_block_response(policy_name: &str, reason: &str) -> Result<Response> {
+    let headers = Headers::new();
+    headers.set("content-type", "application/json")?;
+    headers.set("x-noveum-guard-blocked", "true")?;
+    let body = json!({
+        "error": {
+            "message": format!("Blocked by Nova Guard policy '{policy_name}': {reason}"),
+            "type": "guard_blocked",
+            "code": "noveum_guard_blocked",
+        }
+    });
+    Ok(Response::from_json(&body)?
+        .with_headers(headers)
+        .with_status(200))
+}
+
 #[event(fetch)]
 async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
     let path = req.path();
 
     if path == "/health" {
-        return Response::from_json(&serde_json::json!({
+        return Response::from_json(&json!({
             "status": "healthy",
             "version": env!("CARGO_PKG_VERSION"),
             "runtime": "cloudflare-worker",
@@ -70,68 +97,145 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .ok()
         .flatten()
         .unwrap_or_else(|| "openai".to_string());
-
-    let Some(route) = resolve_provider(&provider) else {
+    let is_anthropic = provider.eq_ignore_ascii_case("anthropic");
+    let route = resolve_provider(&provider);
+    if route.is_none() && !is_anthropic {
         return Response::error(
             format!("Unsupported or not-yet-ported provider on edge: {provider}"),
             400,
         );
-    };
+    }
 
-    // Read the body once (JSON chat bodies are text).
+    // Read + parse the body once (JSON chat bodies are text).
     let body_text = req.text().await.unwrap_or_default();
+    let mut body_json: Option<Value> = serde_json::from_str(&body_text).ok();
+    let model = body_json
+        .as_ref()
+        .and_then(|j| j.get("model"))
+        .and_then(|m| m.as_str())
+        .unwrap_or("")
+        .to_string();
 
-    // --- Nova Guard input phase (shared engine) ---
     let engine = build_engine(&env);
-    if engine.is_enabled() && engine.active_policy_count() > 0 {
-        if let Ok(body_json) = serde_json::from_str::<serde_json::Value>(&body_text) {
-            let model = body_json
-                .get("model")
-                .and_then(|m| m.as_str())
-                .unwrap_or("")
-                .to_string();
-            let input_text = flatten_input_text(&body_json);
-            let result = engine.evaluate(
-                Phase::Input,
-                &model,
-                &input_text,
-                Some(&body_json),
-                None,
-                None,
-            );
+    let guard_active = engine.is_enabled() && engine.active_policy_count() > 0;
+
+    // --- Nova Guard input phase (block, then redact/mask transforms) ---
+    if guard_active {
+        if let Some(json) = &body_json {
+            let input_text = flatten_input_text(json);
+            let result = engine.evaluate(Phase::Input, &model, &input_text, Some(json), None, None);
             if let Some(block) = &result.block {
-                let headers = Headers::new();
-                headers.set("content-type", "application/json")?;
-                headers.set("x-noveum-guard-blocked", "true")?;
-                let body = serde_json::json!({
-                    "error": {
-                        "message": format!("Request blocked by Nova Guard policy '{}': {}", block.policy_name, block.reason),
-                        "type": "guard_blocked",
-                        "code": "noveum_guard_blocked",
-                    }
-                });
-                return Ok(Response::from_json(&body)?
-                    .with_headers(headers)
-                    .with_status(200));
+                return guard_block_response(&block.policy_name, &block.reason);
             }
-            // (Transform/redact + output phase land in a later phase.)
+        }
+        if let Some(json) = body_json.as_mut() {
+            apply_input_transforms(&engine, &model, json);
         }
     }
 
-    // --- Proxy to the upstream provider via the platform Fetch API ---
-    let url = upstream_url(&route, &path);
+    // The body to forward (carries any input redactions).
+    let forward_body = match &body_json {
+        Some(j) => serde_json::to_string(j).unwrap_or_else(|_| body_text.clone()),
+        None => body_text.clone(),
+    };
 
-    let out_headers = Headers::new();
-    if let Ok(Some(auth)) = req.headers().get("authorization") {
-        out_headers.set("authorization", &auth)?;
-    }
-    out_headers.set("content-type", "application/json")?;
+    // --- Build the outbound request (provider-specific routing/auth) ---
+    let (url, out_headers) = if is_anthropic {
+        let headers = Headers::new();
+        headers.set("content-type", "application/json")?;
+        headers.set("anthropic-version", "2023-06-01")?;
+        if let Ok(Some(auth)) = req.headers().get("authorization") {
+            let key = auth.trim_start_matches("Bearer ").trim();
+            headers.set("x-api-key", key)?;
+        }
+        ("https://api.anthropic.com/v1/messages".to_string(), headers)
+    } else {
+        let route = route.expect("checked above");
+        let headers = Headers::new();
+        headers.set("content-type", "application/json")?;
+        if let Ok(Some(auth)) = req.headers().get("authorization") {
+            headers.set("authorization", &auth)?;
+        }
+        (upstream_url(&route, &path), headers)
+    };
 
     let mut init = RequestInit::new();
     init.with_method(Method::Post)
         .with_headers(out_headers)
-        .with_body(Some(body_text.into()));
-
+        .with_body(Some(forward_body.into()));
     let out_req = Request::new_with_init(&url, &init)?;
-    Fetch::Request(out_req).send().await
+    let mut resp = Fetch::Request(out_req).send().await?;
+
+    // --- Response phase ---
+    let is_stream = resp
+        .headers()
+        .get("content-type")
+        .ok()
+        .flatten()
+        .map(|ct| ct.contains("text/event-stream"))
+        .unwrap_or(false);
+
+    // Streaming passes through untouched (matches native v1; Anthropic SSE stays
+    // in Anthropic shape, exactly like the native server).
+    if is_stream {
+        return Ok(resp);
+    }
+
+    // Non-streaming: only buffer when we must transform (Anthropic) or run the
+    // output phase; otherwise stream the upstream response straight back.
+    if !is_anthropic && !guard_active {
+        return Ok(resp);
+    }
+
+    // Don't buffer responses beyond the inspection cap — pass them through
+    // uninspected rather than risk OOM on the 128 MB isolate (matches native).
+    const MAX_BODY: u64 = 8 * 1024 * 1024;
+    let too_large = resp
+        .headers()
+        .get("content-length")
+        .ok()
+        .flatten()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(|n| n > MAX_BODY)
+        .unwrap_or(false);
+    if too_large {
+        return Ok(resp);
+    }
+
+    let status = resp.status_code();
+    let text = resp.text().await.unwrap_or_default();
+    let mut out_json: Value = match serde_json::from_str(&text) {
+        Ok(v) => v,
+        Err(_) => return Ok(Response::ok(text)?.with_status(status)),
+    };
+
+    // Anthropic → OpenAI shape for parity (only successful responses carry the
+    // Messages body; errors pass through as-is).
+    if is_anthropic && (200..300).contains(&status) {
+        let created = (Date::now().as_millis() / 1000) as i64;
+        out_json = transform_anthropic_to_openai_format(out_json, created);
+    }
+
+    // Output phase — every edge response is OpenAI-shaped at this point.
+    if guard_active {
+        let output_text = flatten_output_text("openai", &out_json);
+        if !output_text.is_empty() {
+            let result = engine.evaluate(
+                Phase::Output,
+                &model,
+                &output_text,
+                Some(&out_json),
+                None,
+                None,
+            );
+            if let Some(block) = &result.block {
+                return guard_block_response(&block.policy_name, &block.reason);
+            }
+            if let Some(transformed) = &result.transformed_text {
+                rewrite_output_text("openai", &mut out_json, transformed);
+            }
+        }
+    }
+
+    Ok(Response::from_json(&out_json)?.with_status(status))
 }

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -1,0 +1,137 @@
+//! Cloudflare Worker runtime (WASM).
+//!
+//! This is the `wasm32` entry point: a `#[event(fetch)]` handler that runs the
+//! gateway as a true per‑PoP edge Worker. It reuses the **shared Nova Guard
+//! engine** ([`crate::policy`]) for input enforcement, then proxies the request
+//! to the upstream provider via the platform `Fetch` API (no `reqwest`/`tokio`).
+//!
+//! Parity with the native server: same provider routing, same `x-provider`
+//! contract, same Nova Guard decisions. Bedrock (AWS SigV4 via Web Crypto) and
+//! streaming output‑phase enforcement land in later phases.
+
+use worker::*;
+
+use crate::policy::{decision::Phase, PolicyEngine};
+use crate::routing::{flatten_input_text, resolve_provider, upstream_url};
+
+/// Build the Nova Guard engine from an in‑memory bundle.
+///
+/// On the edge, policies come from the `NOVEUM_GUARD_POLICIES` Worker var/secret
+/// (inline JSON) or KV (future); there is no filesystem. Absent/invalid config
+/// degrades to a transparent pass‑through, exactly like the native `from_env`.
+fn build_engine(env: &Env) -> PolicyEngine {
+    use crate::policy::config::PolicyBundle;
+    use crate::policy::engine::EngineOptions;
+
+    let enabled = env
+        .var("NOVEUM_GUARD_ENABLED")
+        .map(|v| {
+            !matches!(
+                v.to_string().trim().to_ascii_lowercase().as_str(),
+                "false" | "0" | "no" | "off" | "disabled" | ""
+            )
+        })
+        .unwrap_or(true);
+
+    let opts = EngineOptions {
+        enabled,
+        ..Default::default()
+    };
+
+    let bundle = env
+        .var("NOVEUM_GUARD_POLICIES")
+        .ok()
+        .map(|v| v.to_string())
+        .and_then(|s| PolicyBundle::from_json_str(&s).ok())
+        .unwrap_or_default();
+
+    PolicyEngine::from_bundle(&bundle, opts)
+}
+
+#[event(fetch)]
+async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
+    let path = req.path();
+
+    if path == "/health" {
+        return Response::from_json(&serde_json::json!({
+            "status": "healthy",
+            "version": env!("CARGO_PKG_VERSION"),
+            "runtime": "cloudflare-worker",
+        }));
+    }
+
+    if req.method() != Method::Post || !path.starts_with("/v1/") {
+        return Response::error("Not Found", 404);
+    }
+
+    let provider = req
+        .headers()
+        .get("x-provider")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| "openai".to_string());
+
+    let Some(route) = resolve_provider(&provider) else {
+        return Response::error(
+            format!("Unsupported or not-yet-ported provider on edge: {provider}"),
+            400,
+        );
+    };
+
+    // Read the body once (JSON chat bodies are text).
+    let body_text = req.text().await.unwrap_or_default();
+
+    // --- Nova Guard input phase (shared engine) ---
+    let engine = build_engine(&env);
+    if engine.is_enabled() && engine.active_policy_count() > 0 {
+        if let Ok(body_json) = serde_json::from_str::<serde_json::Value>(&body_text) {
+            let model = body_json
+                .get("model")
+                .and_then(|m| m.as_str())
+                .unwrap_or("")
+                .to_string();
+            let input_text = flatten_input_text(&body_json);
+            let result = engine.evaluate(
+                Phase::Input,
+                &model,
+                &input_text,
+                Some(&body_json),
+                None,
+                None,
+            );
+            if let Some(block) = &result.block {
+                let headers = Headers::new();
+                headers.set("content-type", "application/json")?;
+                headers.set("x-noveum-guard-blocked", "true")?;
+                let body = serde_json::json!({
+                    "error": {
+                        "message": format!("Request blocked by Nova Guard policy '{}': {}", block.policy_name, block.reason),
+                        "type": "guard_blocked",
+                        "code": "noveum_guard_blocked",
+                    }
+                });
+                return Ok(Response::from_json(&body)?
+                    .with_headers(headers)
+                    .with_status(200));
+            }
+            // (Transform/redact + output phase land in a later phase.)
+        }
+    }
+
+    // --- Proxy to the upstream provider via the platform Fetch API ---
+    let url = upstream_url(&route, &path);
+
+    let out_headers = Headers::new();
+    if let Ok(Some(auth)) = req.headers().get("authorization") {
+        out_headers.set("authorization", &auth)?;
+    }
+    out_headers.set("content-type", "application/json")?;
+
+    let mut init = RequestInit::new();
+    init.with_method(Method::Post)
+        .with_headers(out_headers)
+        .with_body(Some(body_text.into()));
+
+    let out_req = Request::new_with_init(&url, &init)?;
+    Fetch::Request(out_req).send().await
+}

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -8,25 +8,37 @@
 //! `reqwest`/`tokio`).
 //!
 //! Parity with the native server: same provider routing, same `x-provider`
-//! contract, same Nova Guard input/output decisions + redaction, and the same
+//! contract, same Nova Guard input/output decisions + redaction, the same block
+//! response modes (`NOVEUM_GUARD_BLOCK_RESPONSE_MODE`), and the same
 //! Anthropic→OpenAI response conversion. Streaming responses pass through
 //! without output‑phase enforcement (the documented v1 limitation, identical to
-//! native). Bedrock (AWS SigV4 via Web Crypto) lands in a later phase.
+//! native). Non‑JSON `/v1/*` bodies are forwarded byte‑for‑byte. Bedrock (AWS
+//! SigV4 via Web Crypto) lands in a later phase.
 
+use futures_util::StreamExt;
 use serde_json::{json, Value};
 use worker::*;
 
-use crate::policy::{decision::Phase, PolicyEngine};
+use crate::policy::decision::{Phase, PolicyDecision};
+use crate::policy::synthetic::{block_body, block_status, policy_header_token, BlockResponseMode};
+use crate::policy::PolicyEngine;
 use crate::routing::{
-    apply_input_transforms, flatten_input_text, flatten_output_text, resolve_provider,
-    rewrite_output_text, transform_anthropic_to_openai_format, upstream_url,
+    apply_input_transforms, apply_output_transforms, flatten_input_text, flatten_output_text,
+    resolve_provider, transform_anthropic_to_openai_format, upstream_url,
 };
+
+/// Max response size we will buffer for output-phase inspection. Larger
+/// responses pass through uninspected (matches native; avoids OOM on the
+/// 128 MB isolate).
+const MAX_BODY: usize = 8 * 1024 * 1024;
 
 /// Build the Nova Guard engine from an in‑memory bundle.
 ///
 /// On the edge, policies come from the `NOVEUM_GUARD_POLICIES` Worker var/secret
 /// (inline JSON) or KV (future); there is no filesystem. Absent/invalid config
 /// degrades to a transparent pass‑through, exactly like the native `from_env`.
+/// Honors `NOVEUM_GUARD_BLOCK_RESPONSE_MODE` the same way `PolicyEngine::from_env`
+/// does, so block shapes match the native server.
 fn build_engine(env: &Env) -> PolicyEngine {
     use crate::policy::config::PolicyBundle;
     use crate::policy::engine::EngineOptions;
@@ -41,8 +53,14 @@ fn build_engine(env: &Env) -> PolicyEngine {
         })
         .unwrap_or(true);
 
+    let block_mode = env
+        .var("NOVEUM_GUARD_BLOCK_RESPONSE_MODE")
+        .map(|v| BlockResponseMode::from_env_str(&v.to_string()))
+        .unwrap_or(BlockResponseMode::SyntheticSuccess);
+
     let opts = EngineOptions {
         enabled,
+        block_mode,
         ..Default::default()
     };
 
@@ -56,23 +74,42 @@ fn build_engine(env: &Env) -> PolicyEngine {
     PolicyEngine::from_bundle(&bundle, opts)
 }
 
-/// Nova Guard block envelope (OpenAI-style error). Returned with HTTP 200 +
-/// `x-noveum-guard-blocked` so clients can detect a guard block distinctly from
-/// an upstream error.
-fn guard_block_response(policy_name: &str, reason: &str) -> Result<Response> {
+/// Build a Nova Guard block response in the engine's configured mode, using the
+/// SHARED body/status builders so it is byte-identical to the native server.
+fn guard_block_response(
+    provider: &str,
+    model: &str,
+    decision: &PolicyDecision,
+    mode: BlockResponseMode,
+) -> Result<Response> {
+    let body = block_body(provider, model, decision, mode);
     let headers = Headers::new();
     headers.set("content-type", "application/json")?;
     headers.set("x-noveum-guard-blocked", "true")?;
-    let body = json!({
-        "error": {
-            "message": format!("Blocked by Nova Guard policy '{policy_name}': {reason}"),
-            "type": "guard_blocked",
-            "code": "noveum_guard_blocked",
-        }
-    });
+    headers.set(
+        "x-noveum-guard-policy",
+        &policy_header_token(&decision.policy_id),
+    )?;
     Ok(Response::from_json(&body)?
         .with_headers(headers)
-        .with_status(200))
+        .with_status(block_status(mode)))
+}
+
+/// Read a response body with a hard byte cap. Reads incrementally so a chunked /
+/// missing-`Content-Length` body cannot blow past the cap and OOM the isolate.
+/// `Err(())` means the body exceeded the cap (it can't be safely re-streamed) —
+/// the caller returns 502, matching native's behavior.
+async fn read_body_capped(resp: &mut Response) -> core::result::Result<Vec<u8>, ()> {
+    let mut stream = resp.stream().map_err(|_| ())?;
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|_| ())?;
+        if buf.len() + chunk.len() > MAX_BODY {
+            return Err(());
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
 }
 
 #[event(fetch)]
@@ -106,9 +143,27 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         );
     }
 
-    // Read + parse the body once (JSON chat bodies are text).
-    let body_text = req.text().await.unwrap_or_default();
-    let mut body_json: Option<Value> = serde_json::from_str(&body_text).ok();
+    // Only JSON bodies are parsed/guarded/transformed. Non-JSON (multipart,
+    // binary) bodies are forwarded byte-for-byte, like the native proxy.
+    let is_json_req = req
+        .headers()
+        .get("content-type")
+        .ok()
+        .flatten()
+        .map(|ct| ct.to_ascii_lowercase().contains("application/json"))
+        .unwrap_or(false);
+
+    let engine = build_engine(&env);
+    let guard_active = engine.is_enabled() && engine.active_policy_count() > 0;
+    let block_mode = engine.block_mode();
+
+    // Read the raw request body once (so non-JSON forwards unchanged).
+    let body_bytes = req.bytes().await.unwrap_or_default();
+    let mut body_json: Option<Value> = if is_json_req {
+        serde_json::from_slice(&body_bytes).ok()
+    } else {
+        None
+    };
     let model = body_json
         .as_ref()
         .and_then(|j| j.get("model"))
@@ -116,28 +171,19 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .unwrap_or("")
         .to_string();
 
-    let engine = build_engine(&env);
-    let guard_active = engine.is_enabled() && engine.active_policy_count() > 0;
-
     // --- Nova Guard input phase (block, then redact/mask transforms) ---
     if guard_active {
-        if let Some(json) = &body_json {
-            let input_text = flatten_input_text(json);
-            let result = engine.evaluate(Phase::Input, &model, &input_text, Some(json), None, None);
+        if let Some(j) = &body_json {
+            let input_text = flatten_input_text(j);
+            let result = engine.evaluate(Phase::Input, &model, &input_text, Some(j), None, None);
             if let Some(block) = &result.block {
-                return guard_block_response(&block.policy_name, &block.reason);
+                return guard_block_response(&provider, &model, block, block_mode);
             }
         }
-        if let Some(json) = body_json.as_mut() {
-            apply_input_transforms(&engine, &model, json);
+        if let Some(j) = body_json.as_mut() {
+            apply_input_transforms(&engine, &model, j);
         }
     }
-
-    // The body to forward (carries any input redactions).
-    let forward_body = match &body_json {
-        Some(j) => serde_json::to_string(j).unwrap_or_else(|_| body_text.clone()),
-        None => body_text.clone(),
-    };
 
     // --- Build the outbound request (provider-specific routing/auth) ---
     let (url, out_headers) = if is_anthropic {
@@ -159,10 +205,20 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         (upstream_url(&route, &path), headers)
     };
 
+    // Forward the (possibly redacted) JSON as a string, or the original bytes
+    // verbatim for non-JSON requests.
     let mut init = RequestInit::new();
-    init.with_method(Method::Post)
-        .with_headers(out_headers)
-        .with_body(Some(forward_body.into()));
+    init.with_method(Method::Post).with_headers(out_headers);
+    match &body_json {
+        Some(j) => {
+            init.with_body(Some(serde_json::to_string(j).unwrap_or_default().into()));
+        }
+        None => {
+            let arr = js_sys::Uint8Array::new_with_length(body_bytes.len() as u32);
+            arr.copy_from(&body_bytes);
+            init.with_body(Some(arr.into()));
+        }
+    }
     let out_req = Request::new_with_init(&url, &init)?;
     let mut resp = Fetch::Request(out_req).send().await?;
 
@@ -187,26 +243,37 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return Ok(resp);
     }
 
-    // Don't buffer responses beyond the inspection cap — pass them through
-    // uninspected rather than risk OOM on the 128 MB isolate (matches native).
-    const MAX_BODY: u64 = 8 * 1024 * 1024;
-    let too_large = resp
+    // Fast path: a declared length over the cap → pass through unbuffered.
+    let declared = resp
         .headers()
         .get("content-length")
         .ok()
         .flatten()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(|n| n > MAX_BODY)
-        .unwrap_or(false);
-    if too_large {
+        .and_then(|v| v.parse::<usize>().ok());
+    if matches!(declared, Some(n) if n > MAX_BODY) {
         return Ok(resp);
     }
 
     let status = resp.status_code();
-    let text = resp.text().await.unwrap_or_default();
-    let mut out_json: Value = match serde_json::from_str(&text) {
+
+    // Read with a hard cap (covers chunked / missing Content-Length).
+    let bytes = match read_body_capped(&mut resp).await {
+        Ok(b) => b,
+        Err(()) => {
+            let headers = Headers::new();
+            headers.set("content-type", "application/json")?;
+            return Ok(Response::from_json(&json!({
+                "error": {"message": "upstream response exceeded gateway inspection limit", "type": "gateway_error"}
+            }))?
+            .with_headers(headers)
+            .with_status(502));
+        }
+    };
+
+    let mut out_json: Value = match serde_json::from_slice(&bytes) {
         Ok(v) => v,
-        Err(_) => return Ok(Response::ok(text)?.with_status(status)),
+        // Not JSON — return the buffered bytes unchanged with the upstream status.
+        Err(_) => return Ok(Response::from_bytes(bytes)?.with_status(status)),
     };
 
     // Anthropic → OpenAI shape for parity (only successful responses carry the
@@ -229,10 +296,10 @@ async fn fetch(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
                 None,
             );
             if let Some(block) = &result.block {
-                return guard_block_response(&block.policy_name, &block.reason);
+                return guard_block_response("openai", &model, block, block_mode);
             }
-            if let Some(transformed) = &result.transformed_text {
-                rewrite_output_text("openai", &mut out_json, transformed);
+            if result.transformed_text.is_some() {
+                apply_output_transforms(&engine, &model, "openai", &mut out_json);
             }
         }
     }

--- a/src/worker_rt.rs
+++ b/src/worker_rt.rs
@@ -10,10 +10,12 @@
 //! Parity with the native server: same provider routing, same `x-provider`
 //! contract, header pass‑through, query pass‑through, same Nova Guard
 //! input/output decisions + redaction, the same block response modes
-//! (`NOVEUM_GUARD_BLOCK_RESPONSE_MODE`), and the same Anthropic→OpenAI response
-//! conversion. Streaming responses pass through without output‑phase enforcement
-//! (the documented v1 limitation, identical to native). Non‑JSON `/v1/*` bodies
-//! are forwarded byte‑for‑byte. Bedrock (AWS SigV4 via Web Crypto) lands later.
+//! (`NOVEUM_GUARD_BLOCK_RESPONSE_MODE`), and the same Anthropic→OpenAI and
+//! Bedrock-Converse→OpenAI response conversions. Bedrock is signed with AWS
+//! SigV4 (see [`crate::sigv4`]) and additionally supports temporary credentials
+//! (`x-aws-session-token`). Streaming responses pass through without output‑phase
+//! enforcement (the documented v1 limitation, identical to native). Non‑JSON
+//! `/v1/*` bodies are forwarded byte‑for‑byte.
 
 use futures_util::StreamExt;
 use serde_json::{json, Value};
@@ -23,9 +25,68 @@ use crate::policy::decision::{Phase, PolicyDecision};
 use crate::policy::synthetic::{block_body, block_status, policy_header_token, BlockResponseMode};
 use crate::policy::PolicyEngine;
 use crate::routing::{
-    apply_input_transforms, apply_output_transforms, flatten_input_text, flatten_output_text,
-    resolve_provider, transform_anthropic_to_openai_format, upstream_url,
+    apply_input_transforms, apply_output_transforms, bedrock_converse_to_openai,
+    flatten_input_text, flatten_output_text, openai_to_bedrock_converse, resolve_provider,
+    transform_anthropic_to_openai_format, upstream_url,
 };
+use crate::sigv4;
+
+/// Default Bedrock model + region (mirrors the native `BedrockProvider`).
+const BEDROCK_DEFAULT_MODEL: &str = "amazon.titan-text-premier-v1:0";
+const BEDROCK_DEFAULT_REGION: &str = "us-east-1";
+
+/// AWS credentials for a Bedrock request, taken from `x-aws-*` headers.
+struct BedrockCreds {
+    access_key: String,
+    secret_key: String,
+    session_token: Option<String>,
+    region: String,
+}
+
+/// Extract Bedrock credentials from request headers (supports temporary creds
+/// via `x-aws-session-token`, which the native path does not).
+fn bedrock_credentials(req: &Request) -> Option<BedrockCreds> {
+    let h = req.headers();
+    let access_key = h.get("x-aws-access-key-id").ok().flatten()?;
+    let secret_key = h.get("x-aws-secret-access-key").ok().flatten()?;
+    let session_token = h.get("x-aws-session-token").ok().flatten();
+    let region = h
+        .get("x-aws-region")
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| BEDROCK_DEFAULT_REGION.to_string());
+    Some(BedrockCreds {
+        access_key,
+        secret_key,
+        session_token,
+        region,
+    })
+}
+
+/// Current UTC time as SigV4 `(amz_date = YYYYMMDDTHHMMSSZ, datestamp = YYYYMMDD)`.
+fn amz_timestamps() -> (String, String) {
+    let d = js_sys::Date::new_0();
+    let year = d.get_utc_full_year();
+    let month = d.get_utc_month() + 1; // JS months are 0-based
+    let day = d.get_utc_date();
+    let hour = d.get_utc_hours();
+    let min = d.get_utc_minutes();
+    let sec = d.get_utc_seconds();
+    let datestamp = format!("{year:04}{month:02}{day:02}");
+    let amz_date = format!("{datestamp}T{hour:02}{min:02}{sec:02}Z");
+    (amz_date, datestamp)
+}
+
+/// The bytes to forward upstream: redacted JSON re-serialized, else the original
+/// request bytes verbatim.
+fn forward_body_bytes(redacted: bool, body_json: &Option<Value>, original: &[u8]) -> Vec<u8> {
+    if redacted {
+        if let Some(j) = body_json {
+            return serde_json::to_vec(j).unwrap_or_else(|_| original.to_vec());
+        }
+    }
+    original.to_vec()
+}
 
 /// Max response size we will buffer for output-phase inspection. Larger
 /// responses pass through uninspected (matches native; avoids OOM on the
@@ -204,8 +265,9 @@ async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         .flatten()
         .unwrap_or_else(|| "openai".to_string());
     let is_anthropic = provider.eq_ignore_ascii_case("anthropic");
+    let is_bedrock = provider.eq_ignore_ascii_case("bedrock");
     let route = resolve_provider(&provider);
-    if route.is_none() && !is_anthropic {
+    if route.is_none() && !is_anthropic && !is_bedrock {
         return Response::error(
             format!("Unsupported or not-yet-ported provider on edge: {provider}"),
             400,
@@ -235,9 +297,9 @@ async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
     // Read the raw request body once.
     let body_bytes = req.bytes().await.unwrap_or_default();
 
-    // Parse JSON only when we actually need to inspect it (guard on). A
-    // transparent proxy forwards the original bytes byte-for-byte.
-    let mut body_json: Option<Value> = if guard_active && is_json_req {
+    // Parse JSON when we need to inspect (guard on) or transform it (Bedrock
+    // converts OpenAI→Converse). A transparent proxy forwards bytes byte-for-byte.
+    let mut body_json: Option<Value> = if (guard_active || is_bedrock) && is_json_req {
         serde_json::from_slice(&body_bytes).ok()
     } else {
         None
@@ -264,37 +326,86 @@ async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         }
     }
 
-    // --- Build the outbound request (forward client headers + provider auth) ---
-    let out_headers = copy_headers_excluding(req.headers(), REQUEST_SKIP_HEADERS)?;
-    let url = if is_anthropic {
+    // --- Build the outbound request (provider-specific routing/auth/body) ---
+    let url: String;
+    let out_headers: Headers;
+    let forward_bytes: Vec<u8>;
+
+    if is_bedrock {
+        // AWS Bedrock Converse, signed with SigV4 (temporary creds supported).
+        let Some(creds) = bedrock_credentials(&req) else {
+            return Response::error(
+                "Bedrock requires x-aws-access-key-id and x-aws-secret-access-key headers",
+                400,
+            );
+        };
+        let Some(body) = body_json.as_ref() else {
+            return Response::error("Bedrock requires a JSON chat-completions body", 400);
+        };
+        let effective_model = if model.is_empty() {
+            BEDROCK_DEFAULT_MODEL
+        } else {
+            model.as_str()
+        };
+        forward_bytes = serde_json::to_vec(&openai_to_bedrock_converse(body)).unwrap_or_default();
+
+        let host = format!("bedrock-runtime.{}.amazonaws.com", creds.region);
+        // Wire path keeps the literal `:` (AWS re-encodes it); ARN `/` → %2F so
+        // the id stays one segment. The SigV4 canonical URI must additionally
+        // encode `:` → %3A to match AWS's canonicalization (what `aws-sigv4` does
+        // internally on the native path).
+        let wire_uri = format!("/model/{}/converse", effective_model.replace('/', "%2F"));
+        let canonical_uri = wire_uri.replace(':', "%3A");
+        url = format!("https://{host}{wire_uri}");
+
+        let (amz_date, datestamp) = amz_timestamps();
+        let signed = sigv4::sign(
+            "POST",
+            &host,
+            &canonical_uri,
+            "",
+            &forward_bytes,
+            &creds.access_key,
+            &creds.secret_key,
+            creds.session_token.as_deref(),
+            &creds.region,
+            "bedrock",
+            &amz_date,
+            &datestamp,
+        );
+        out_headers = Headers::new();
+        out_headers.set("content-type", "application/json")?;
+        out_headers.set("x-amz-date", &signed.amz_date)?;
+        out_headers.set("authorization", &signed.authorization)?;
+        if let Some(token) = &signed.security_token {
+            out_headers.set("x-amz-security-token", token)?;
+        }
+    } else if is_anthropic {
         // Anthropic uses x-api-key + anthropic-version, not Bearer auth.
+        out_headers = copy_headers_excluding(req.headers(), REQUEST_SKIP_HEADERS)?;
         out_headers.delete("authorization")?;
         out_headers.set("anthropic-version", "2023-06-01")?;
         if let Ok(Some(auth)) = req.headers().get("authorization") {
             out_headers.set("x-api-key", auth.trim_start_matches("Bearer ").trim())?;
         }
-        "https://api.anthropic.com/v1/messages".to_string()
+        url = "https://api.anthropic.com/v1/messages".to_string();
+        forward_bytes = forward_body_bytes(redacted, &body_json, &body_bytes);
     } else {
         let route = route.expect("checked above");
+        out_headers = copy_headers_excluding(req.headers(), REQUEST_SKIP_HEADERS)?;
         let base = upstream_url(&route, &path);
-        match &query {
+        url = match &query {
             Some(q) => format!("{base}?{q}"),
             None => base,
-        }
-    };
+        };
+        forward_bytes = forward_body_bytes(redacted, &body_json, &body_bytes);
+    }
 
-    // Forward the redacted JSON (re-serialized) or the original bytes verbatim.
     let mut init = RequestInit::new();
     init.with_method(Method::Post).with_headers(out_headers);
-    if redacted {
-        if let Some(j) = &body_json {
-            init.with_body(Some(serde_json::to_string(j).unwrap_or_default().into()));
-        }
-    } else {
-        let arr = js_sys::Uint8Array::new_with_length(body_bytes.len() as u32);
-        arr.copy_from(&body_bytes);
-        init.with_body(Some(arr.into()));
-    }
+    let arr = js_sys::Uint8Array::new_with_length(forward_bytes.len() as u32);
+    arr.copy_from(&forward_bytes);
+    init.with_body(Some(arr.into()));
     let out_req = Request::new_with_init(&url, &init)?;
     let mut resp = Fetch::Request(out_req).send().await?;
 
@@ -313,9 +424,9 @@ async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         return passthrough(resp);
     }
 
-    // Non-streaming: only buffer when we must transform (Anthropic) or run the
-    // output phase; otherwise stream the upstream response straight back.
-    if !is_anthropic && !guard_active {
+    // Non-streaming: only buffer when we must transform (Anthropic/Bedrock) or
+    // run the output phase; otherwise stream the upstream response straight back.
+    if !is_anthropic && !is_bedrock && !guard_active {
         return passthrough(resp);
     }
 
@@ -359,11 +470,20 @@ async fn handle(mut req: Request, env: Env, _ctx: Context) -> Result<Response> {
         }
     };
 
-    // Anthropic → OpenAI shape for parity (only successful responses carry the
-    // Messages body; errors pass through as-is).
-    if is_anthropic && (200..300).contains(&status) {
+    // Convert provider-native responses to OpenAI shape for parity (only on 2xx;
+    // error envelopes pass through unchanged).
+    if (200..300).contains(&status) {
         let created = (Date::now().as_millis() / 1000) as i64;
-        out_json = transform_anthropic_to_openai_format(out_json, created);
+        if is_bedrock {
+            let model_name = if model.is_empty() {
+                BEDROCK_DEFAULT_MODEL
+            } else {
+                model.as_str()
+            };
+            out_json = bedrock_converse_to_openai(&out_json, model_name, created);
+        } else if is_anthropic {
+            out_json = transform_anthropic_to_openai_format(out_json, created);
+        }
     }
 
     // Output phase — every edge response is OpenAI-shaped at this point.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -16,7 +16,11 @@ command = "worker-build --release"
 # Nova Guard policies for the edge (inline JSON). Empty/absent = transparent
 # pass-through, identical to the native gateway with no policies. For production,
 # prefer a Workers KV binding (see docs/CLOUDFLARE_DEPLOYMENT.md).
+#
+# This example exercises all three enforcement paths so parity is demonstrable:
+#   1. block-ssn-input     — reject inputs containing a US SSN (input phase)
+#   2. redact-input-phone  — mask phone numbers BEFORE the upstream call (input)
+#   3. redact-output-email — mask emails in the model's RESPONSE (output phase)
 [vars]
 NOVEUM_GUARD_ENABLED = "true"
-# Example: block US SSNs in the input and reject non-allowlisted models.
-NOVEUM_GUARD_POLICIES = '{"policies":[{"name":"block-ssn","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"ssn","regex":"\\d{3}-\\d{2}-\\d{4}"}],"action":"block"}}]}'
+NOVEUM_GUARD_POLICIES = '{"policies":[{"name":"block-ssn-input","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"ssn","regex":"\\d{3}-\\d{2}-\\d{4}"}],"action":"block"}},{"name":"redact-input-phone","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"phone","regex":"\\d{3}-\\d{3}-\\d{4}"}],"action":"redact","redactWith":"[PHONE]"}},{"name":"redact-output-email","type":"regex_match","mode":"enforce","config":{"phase":"output","patterns":[{"name":"email","regex":"[\\w.+-]+@[\\w-]+\\.[\\w.-]+"}],"action":"redact","redactWith":"[EMAIL]"}}]}'

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,14 +13,20 @@ compatibility_date = "2024-11-01"
 [build]
 command = "worker-build --release"
 
-# Nova Guard policies for the edge (inline JSON). Empty/absent = transparent
-# pass-through, identical to the native gateway with no policies. For production,
-# prefer a Workers KV binding (see docs/CLOUDFLARE_DEPLOYMENT.md).
+# Nova Guard configuration. The checked-in default is a TRANSPARENT proxy:
+# no policies are loaded, so `wrangler dev`/`wrangler deploy` will not mutate or
+# reject any traffic. Opt in by setting `NOVEUM_GUARD_POLICIES` (inline JSON, the
+# same schema as the native `nova-guard.json`) — uncomment the example below or,
+# for production, use a `wrangler secret` / Workers KV (see
+# docs/CLOUDFLARE_DEPLOYMENT.md). Optional: `NOVEUM_GUARD_BLOCK_RESPONSE_MODE`
+# (`guard_error` | `provider_error`).
 #
-# This example exercises all three enforcement paths so parity is demonstrable:
-#   1. block-ssn-input     — reject inputs containing a US SSN (input phase)
-#   2. redact-input-phone  — mask phone numbers BEFORE the upstream call (input)
-#   3. redact-output-email — mask emails in the model's RESPONSE (output phase)
+# Example policy set exercising all three enforcement paths (do NOT enable
+# blindly on a shared deployment — it will block SSNs and redact phones/emails):
+#   NOVEUM_GUARD_POLICIES = '{"policies":[
+#     {"name":"block-ssn-input","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"ssn","regex":"\\d{3}-\\d{2}-\\d{4}"}],"action":"block"}},
+#     {"name":"redact-input-phone","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"phone","regex":"\\d{3}-\\d{3}-\\d{4}"}],"action":"redact","redactWith":"[PHONE]"}},
+#     {"name":"redact-output-email","type":"regex_match","mode":"enforce","config":{"phase":"output","patterns":[{"name":"email","regex":"[\\w.+-]+@[\\w-]+\\.[\\w.-]+"}],"action":"redact","redactWith":"[EMAIL]"}}
+#   ]}'
 [vars]
-NOVEUM_GUARD_ENABLED = "true"
-NOVEUM_GUARD_POLICIES = '{"policies":[{"name":"block-ssn-input","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"ssn","regex":"\\d{3}-\\d{2}-\\d{4}"}],"action":"block"}},{"name":"redact-input-phone","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"phone","regex":"\\d{3}-\\d{3}-\\d{4}"}],"action":"redact","redactWith":"[PHONE]"}},{"name":"redact-output-email","type":"regex_match","mode":"enforce","config":{"phase":"output","patterns":[{"name":"email","regex":"[\\w.+-]+@[\\w-]+\\.[\\w.-]+"}],"action":"redact","redactWith":"[EMAIL]"}}]}'
+# (no NOVEUM_GUARD_POLICIES → transparent proxy; set it to enable Nova Guard)

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,22 @@
+# Cloudflare Worker config for the Noveum AI Gateway (edge/WASM deployment).
+#
+# Build:   worker-build --release        (compiles the crate to wasm32 + JS shim)
+# Dev:     npx wrangler dev               (runs locally in workerd at :8787)
+# Deploy:  npx wrangler deploy            (publishes to the global edge)
+#
+# The native binary / Docker image (the published `noveum-ai-gateway` crate) is
+# unaffected by this file — it is a separate deployment shape of the same package.
+name = "noveum-ai-gateway"
+main = "build/worker/shim.mjs"
+compatibility_date = "2024-11-01"
+
+[build]
+command = "worker-build --release"
+
+# Nova Guard policies for the edge (inline JSON). Empty/absent = transparent
+# pass-through, identical to the native gateway with no policies. For production,
+# prefer a Workers KV binding (see docs/CLOUDFLARE_DEPLOYMENT.md).
+[vars]
+NOVEUM_GUARD_ENABLED = "true"
+# Example: block US SSNs in the input and reject non-allowlisted models.
+NOVEUM_GUARD_POLICIES = '{"policies":[{"name":"block-ssn","type":"regex_match","mode":"enforce","config":{"phase":"input","patterns":[{"name":"ssn","regex":"\\d{3}-\\d{2}-\\d{4}"}],"action":"block"}}]}'


### PR DESCRIPTION
## Summary

Makes the **single `noveum-ai-gateway` crate** deployable three ways — native binary / **Docker**, Rust **library**, and a **Cloudflare Worker** (WASM, true per‑PoP edge) — sharing **one** Nova Guard engine + request/response codebase so all shapes behave identically. No new package.

**Deployed & verified live on the global edge** (`*.workers.dev`) against OpenAI, Groq, Gemini, and Anthropic.

## What works on the edge (verified live)
- `/health`
- **All OpenAI-compatible providers**: openai, groq, together, fireworks, mistral, cohere, google/gemini, deepseek, xai/grok, openrouter, perplexity
- **Anthropic**: `/v1/messages` + `Bearer`→`x-api-key`/`anthropic-version` + response converted to OpenAI shape
- **SSE streaming**: passed through unbuffered (input redaction still applies)
- **Nova Guard input phase**: block + redact/mask (full shared engine)
- **Nova Guard output phase**: block + redact on non-streaming responses (8 MB inspection cap)

| Live test | Result |
|---|---|
| OpenAI / Groq / Gemini proxy | ✓ |
| Anthropic → OpenAI shape | ✓ (`object: chat.completion`) |
| Input redact (phone → `[PHONE]`) | ✓ masked before model |
| Output redact (email → `[EMAIL]`) | ✓ masked in response |
| SSN input block | ✓ `x-noveum-guard-blocked` |
| SSE streaming | ✓ |

## How parity is guaranteed
Cargo deps split by target (`cfg(target_arch = "wasm32")` = `worker`; native = Tokio/Axum/reqwest). Native bin gated behind a `native` feature; `lib` adds `cdylib`. The Nova Guard engine, pricing, and **all request/response transforms** live in a shared `routing` module compiled to both targets:
- `apply_input_transforms`, `flatten_output_text`, `rewrite_output_text` (moved out of native-only `policy::middleware`)
- `transform_anthropic_to_openai_format` (moved out of `providers::anthropic`; timestamp passed in since `chrono::Utc::now()` panics on wasm32)

Native middleware + the Anthropic provider now use these shared fns — no second copy to drift. Other wasm-safety fixes: `std::time::Instant` gated (panics on wasm), token cap uses a chars/4 heuristic, `jsonschema` http/file resolvers disabled.

## Tests / quality
- Native: **170 unit + 10 integration** tests green
- **clippy clean on BOTH native and wasm32**; fmt + rustdoc clean
- `worker-build` produces a deployable bundle; verified in `workerd` (`wrangler dev`) and live

## Deploy / test
See [docs/CLOUDFLARE_WORKER.md](docs/CLOUDFLARE_WORKER.md) (build/test/deploy) and [docs/CLOUDFLARE_DEPLOYMENT.md](docs/CLOUDFLARE_DEPLOYMENT.md) (architecture + status). `wrangler.toml` ships an example policy set exercising all three phases.

## Remaining (follow-up)
- **Bedrock** — the one provider still needing AWS SigV4 via Web Crypto (`crypto.subtle`)
- Edge telemetry sink (Analytics Engine / Queues) + Workers-KV policies
- Re-enable `wasm-opt` to shrink the bundle (~3.3 MB → ~1 MB gz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cloudflare Worker deployment alongside the native binary and shared library build, including `/health` and `/v1/*` request routing.
  * Enabled edge operation for OpenAI-compatible, Anthropic, and Bedrock (with SigV4 signing) plus Nova Guard enforcement controls for the Worker.
* **Bug Fixes**
  * Fixed policy output enforcement to apply redaction/transforms across all response choices/segments, not just the first.
* **Documentation**
  * Added Cloudflare Worker and Cloudflare deployment guides; updated README with cross-environment deployment notes.
* **Chores**
  * Updated `.gitignore`, Docker build placeholders, and added a checked-in `wrangler.toml`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->