### PR TITLE
feat: native Bedrock temporary-credential support + wasm-opt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,12 @@ exclude = [
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
-# Cloudflare Worker (worker-build/wasm-pack) build settings. wasm-opt is disabled
-# here because it requires a binaryen install on PATH; enable it in CI once
-# binaryen is available to shrink the bundle further.
+# Cloudflare Worker (worker-build/wasm-pack) build settings. wasm-opt shrinks the
+# bundle; it requires `binaryen` (wasm-opt) on PATH. `-Oz` optimizes for size;
+# `--all-features` lets wasm-opt accept the modern wasm features wasm-bindgen
+# emits (bulk-memory, sign-ext, …), which all run on workerd.
 [package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+wasm-opt = ['-Oz', '--all-features']
 
 [profile.release]
 opt-level = 3

--- a/docs/CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/CLOUDFLARE_DEPLOYMENT.md
@@ -76,9 +76,12 @@ conversion, and **temporary-credential support** (`x-aws-session-token`) that th
 native path lacks. Verified live against `amazon.nova-micro-v1:0` with temporary
 STS credentials, including Nova Guard input block + redaction.
 
-**All 13 providers now run on the edge. Remaining:** edge telemetry sink +
-Workers-KV policies; re-enable `wasm-opt`; (optional) add session-token support
-to the native Bedrock path for full parity.
+**All 13 providers now run on the edge.** Bedrock temporary credentials
+(`x-aws-session-token`) are supported on **both** the edge and the native server,
+and the Worker bundle is built with `wasm-opt -Oz` (~3.0 MB / ~1.06 MB gzipped).
+
+**Remaining:** edge telemetry sink (Workers Analytics Engine / Queues) +
+Workers-KV-backed Nova Guard policies.
 
 ## How Cloudflare runs code (the constraint that drives everything)
 

--- a/docs/CLOUDFLARE_WORKER.md
+++ b/docs/CLOUDFLARE_WORKER.md
@@ -16,9 +16,12 @@ share the Nova Guard engine + provider routing, so behavior is identical.
 rustup target add wasm32-unknown-unknown
 cargo install worker-build           # Rust→WASM bundler for Workers
 npm i -g wrangler                    # or use `npx wrangler`
-# (optional, for smaller bundles) install binaryen so `wasm-opt` is on PATH,
-# then set `wasm-opt = true` in [package.metadata.wasm-pack.profile.release].
+brew install binaryen                # provides `wasm-opt` (the build runs `-Oz`)
 ```
+
+> The build invokes `wasm-opt -Oz` (configured in `Cargo.toml` under
+> `[package.metadata.wasm-pack.profile.release]`). If `wasm-opt` isn't on PATH the
+> build fails — install `binaryen`, or set `wasm-opt = false` to skip optimization.
 
 ## Build the Worker bundle
 
@@ -136,9 +139,9 @@ native server (the engine + request/response shaping are one shared codebase).
 Note the redact replacement key is **`redactWith`** (see `wrangler.toml`).
 
 **All 13 providers now run on the edge** (OpenAI-compatible set + Anthropic +
-Bedrock). **Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
+Bedrock). Bedrock temporary credentials (`x-aws-session-token`) are supported on
+**both** the edge and the native server. The bundle is built with `wasm-opt -Oz`
+(~3.0 MB, ~1.06 MB gzipped — well under the 10 MB paid-plan limit).
+
+**Next (see [CLOUDFLARE_DEPLOYMENT.md](CLOUDFLARE_DEPLOYMENT.md)):**
 - Edge telemetry sink (Workers Analytics Engine / Queues) and Workers-KV policies.
-- Re-enable `wasm-opt` to shrink the bundle (currently ~3.3 MB unoptimized;
-  gzips to ~1 MB, well under the 10 MB paid-plan limit).
-- Optionally add `x-aws-session-token` support to the **native** Bedrock path too
-  (the edge already supports temporary credentials).

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -556,7 +556,7 @@ impl Provider for BedrockProvider {
                 // CORS headers
                 .header("access-control-allow-origin", "*")
                 .header("access-control-allow-methods", "POST, OPTIONS")
-                .header("access-control-allow-headers", "content-type, x-provider, x-aws-access-key-id, x-aws-secret-access-key, x-aws-region")
+                .header("access-control-allow-headers", "content-type, x-provider, x-aws-access-key-id, x-aws-secret-access-key, x-aws-region, x-aws-session-token")
                 .header("access-control-expose-headers", "*")
                 // SSE specific headers for better client compatibility
                 .header("x-accel-buffering", "no")
@@ -630,7 +630,7 @@ impl Provider for BedrockProvider {
             builder = builder
                 .header("access-control-allow-origin", "*")
                 .header("access-control-allow-methods", "POST, OPTIONS")
-                .header("access-control-allow-headers", "content-type, x-provider, x-aws-access-key-id, x-aws-secret-access-key, x-aws-region")
+                .header("access-control-allow-headers", "content-type, x-provider, x-aws-access-key-id, x-aws-secret-access-key, x-aws-region, x-aws-session-token")
                 .header("access-control-expose-headers", "*");
 
             // Add the request ID header if we have one

--- a/src/providers/bedrock.rs
+++ b/src/providers/bedrock.rs
@@ -497,6 +497,13 @@ impl Provider for BedrockProvider {
         Some((access_key.to_string(), secret_key.to_string(), region))
     }
 
+    fn get_session_token(&self, headers: &HeaderMap) -> Option<String> {
+        headers
+            .get("x-aws-session-token")
+            .and_then(|h| h.to_str().ok())
+            .map(String::from)
+    }
+
     fn get_signing_host(&self) -> String {
         let region = self.region.read().clone();
         format!("bedrock-runtime.{}.amazonaws.com", region)
@@ -779,6 +786,17 @@ impl MetricsExtractor for BedrockMetricsExtractor {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn session_token_read_from_header_for_temporary_creds() {
+        let p = BedrockProvider::new();
+        // No header → None (long-lived credentials).
+        assert_eq!(p.get_session_token(&HeaderMap::new()), None);
+        // Present → returned (temporary STS credentials).
+        let mut h = HeaderMap::new();
+        h.insert("x-aws-session-token", "tok-abc123".parse().unwrap());
+        assert_eq!(p.get_session_token(&h).as_deref(), Some("tok-abc123"));
+    }
 
     #[test]
     fn transform_path_url_encodes_slash_in_arn_model() {

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -58,6 +58,12 @@ pub trait Provider: Send + Sync {
         None
     }
 
+    /// Get the AWS session token for temporary (STS) credentials, if present.
+    /// Returns `None` for long-lived credentials.
+    fn get_session_token(&self, _headers: &HeaderMap) -> Option<String> {
+        None
+    }
+
     /// Get the signing host for the provider
     fn get_signing_host(&self) -> String {
         self.base_url()

--- a/src/proxy/mod.rs
+++ b/src/proxy/mod.rs
@@ -53,12 +53,14 @@ pub async fn proxy_request_to_provider(
     // Handle AWS signing if required
     let final_headers = if provider.requires_signing() {
         if let Some((access_key, secret_key, region)) = provider.get_signing_credentials(&headers) {
+            let session_token = provider.get_session_token(&headers);
             signing::sign_aws_request(
                 original_request.method().as_str(),
                 &url,
                 &prepared_body,
                 &access_key,
                 &secret_key,
+                session_token,
                 &region,
                 "bedrock",
             )

--- a/src/proxy/signing.rs
+++ b/src/proxy/signing.rs
@@ -6,20 +6,29 @@ use axum::http::HeaderMap;
 use std::time::SystemTime;
 use tracing::debug;
 
+#[allow(clippy::too_many_arguments)]
 pub async fn sign_aws_request(
     method: &str,
     url: &str,
     body: &[u8],
     access_key: &str,
     secret_key: &str,
+    session_token: Option<String>,
     region: &str,
     service: &str,
 ) -> Result<HeaderMap, AppError> {
     debug!("Signing request with method: {}, url: {}", method, url);
 
-    // Create credentials
-    let identity =
-        Credentials::new(access_key, secret_key, None, None, "signing-credentials").into();
+    // Create credentials. `session_token` is `Some` for temporary (STS)
+    // credentials, in which case aws-sigv4 also signs `x-amz-security-token`.
+    let identity = Credentials::new(
+        access_key,
+        secret_key,
+        session_token,
+        None,
+        "signing-credentials",
+    )
+    .into();
 
     // Create signing parameters
     let signing_settings = SigningSettings::default();


### PR DESCRIPTION
Post-v1.2.0 follow-ups from the Cloudflare edge work.

## Native Bedrock temporary credentials (parity with the edge)
- New `Provider::get_session_token` (default `None`), overridden by
  `BedrockProvider` to read `x-aws-session-token`, threaded through
  `proxy` → `signing::sign_aws_request` → `aws-sigv4` `Credentials` so
  `x-amz-security-token` is signed + sent. The native server can now use
  temporary (STS) credentials, matching the edge Worker.
- **Verified live** against `amazon.nova-micro-v1:0` with temporary creds (HTTP
  200, OpenAI `chat.completion` shape).

## Enable `wasm-opt` for the Worker bundle
- `wasm-opt -Oz --all-features` (binaryen). `--all-features` lets wasm-opt accept
  the bulk-memory / sign-ext features wasm-bindgen emits — all run on workerd
  (smoke-tested in `wrangler dev`). Bundle ~3.37 MB → ~3.0 MB raw.

## Tests / quality
- +1 unit test (session-token header). Native **178 unit + 10 integration** green;
  clippy clean on native AND wasm32; fmt clean.

Remaining (tracked separately): edge telemetry sink + Workers-KV-backed policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support added for temporary AWS credentials in Bedrock requests, including session tokens.
  * Cloudflare Worker builds now use stronger WASM optimization for smaller release bundles.

* **Documentation**
  * Updated Cloudflare deployment and Worker setup guides to reflect the latest edge support and build requirements.

* **Bug Fixes**
  * Improved request signing so temporary credentials are handled correctly in edge and native environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->